### PR TITLE
feat: 카카오 회원가입&로그인 구현 완료

### DIFF
--- a/src/main/java/com/shinhan/memento/controller/AuthController.java
+++ b/src/main/java/com/shinhan/memento/controller/AuthController.java
@@ -1,0 +1,29 @@
+package com.shinhan.memento.controller;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.shinhan.memento.dto.MemberDTO;
+import com.shinhan.memento.service.MemberService;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final MemberService memberService;
+
+    private final String clientId = "dd889aeee45cfc71c810b8d5b41a800f";
+    private final String redirectUri = "http://localhost:9999/memento/api/auth/kakao/callback";
+
+    @GetMapping("/api/auth/kakao/callback")
+    public String kakaoLogin(@RequestParam("code") String code, HttpSession session) throws Exception {
+        MemberDTO member = memberService.kakaoLogin(code, clientId, redirectUri);
+        session.setAttribute("loginUser", member);
+        return "redirect:/mainpage/main1";
+    }
+}

--- a/src/main/java/com/shinhan/memento/dto/MemberDTO.java
+++ b/src/main/java/com/shinhan/memento/dto/MemberDTO.java
@@ -27,4 +27,5 @@ public class MemberDTO {
 	Date created_at;
 	Date updated_at;
 	String status;
+	String profile_image_url;
 }

--- a/src/main/java/com/shinhan/memento/service/MemberService.java
+++ b/src/main/java/com/shinhan/memento/service/MemberService.java
@@ -1,0 +1,9 @@
+package com.shinhan.memento.service;
+
+import com.shinhan.memento.dto.MemberDTO;
+
+public interface MemberService {
+    MemberDTO findByEmail(String email);
+    void insertMember(MemberDTO dto);
+    MemberDTO kakaoLogin(String code, String clientId, String redirectUri) throws Exception;
+}

--- a/src/main/java/com/shinhan/memento/service/MemberServiceImpl.java
+++ b/src/main/java/com/shinhan/memento/service/MemberServiceImpl.java
@@ -1,0 +1,168 @@
+package com.shinhan.memento.service;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shinhan.memento.dto.MemberDTO;
+import com.shinhan.memento.util.DBUtil;
+
+@Service
+public class MemberServiceImpl implements MemberService {
+
+    @Override
+    public MemberDTO kakaoLogin(String code, String clientId, String redirectUri) throws Exception {
+        // 1. access token 요청
+        RestTemplate rt = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> tokenRequest = new HttpEntity<>(params, headers);
+        ResponseEntity<String> tokenResponse = rt.postForEntity(
+                "https://kauth.kakao.com/oauth/token",
+                tokenRequest,
+                String.class
+        );
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode tokenJson = objectMapper.readTree(tokenResponse.getBody());
+        String accessToken = tokenJson.get("access_token").asText();
+
+        // 2. 사용자 정보 요청
+        HttpHeaders profileHeaders = new HttpHeaders();
+        profileHeaders.add("Authorization", "Bearer " + accessToken);
+
+        HttpEntity<Void> profileRequest = new HttpEntity<>(profileHeaders);
+        ResponseEntity<String> profileResponse = rt.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.GET,
+                profileRequest,
+                String.class
+        );
+
+        JsonNode userJson = objectMapper.readTree(profileResponse.getBody());
+        String email = userJson.get("kakao_account").get("email").asText();
+        String nickname = userJson.get("properties").get("nickname").asText();
+        String imageUrl = userJson.get("properties").get("profile_image").asText();
+
+        // 3. DB에서 회원 확인 또는 신규 등록
+        MemberDTO member = findByEmail(email);
+
+        if (member == null) {
+            member = MemberDTO.builder()
+                    .email(email)
+                    .nickname(nickname)
+                    .user_type("MENTE")
+                    .point(0)
+                    .score(0)
+                    .match_type_id(1)
+                    .status("ACTIVE")
+                    .created_at(new java.sql.Date(System.currentTimeMillis()))
+                    .profile_image_url(imageUrl)
+                    .build();
+
+            insertMember(member);
+        } else {
+            member.setProfile_image_url(imageUrl); // 기존 회원 프로필 최신화
+        }
+
+        return member;
+    }
+
+    @Override
+    public MemberDTO findByEmail(String email) {
+        MemberDTO member = null;
+        String sql = "SELECT * FROM member WHERE email = ?";
+        try (
+            Connection conn = DBUtil.getConnection();
+            PreparedStatement pstmt = conn.prepareStatement(sql)
+        ) {
+            pstmt.setString(1, email);
+            ResultSet rs = pstmt.executeQuery();
+            if (rs.next()) {
+                member = MemberDTO.builder()
+                        .member_id(rs.getInt("member_id"))
+                        .email(rs.getString("email"))
+                        .nickname(rs.getString("nickname"))
+                        .user_type(rs.getString("user_type"))
+                        .status(rs.getString("status"))
+                        .profile_image_url(rs.getString("profile_image_url"))
+                        .build();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return member;
+    }
+
+    @Override
+    public void insertMember(MemberDTO dto) {
+        String sql = "INSERT INTO member ("
+                   + "member_id, match_type_id, email, nickname, phone_number, "
+                   + "user_type, point, introduce_mento, score, "
+                   + "region_group, region_subgroup, region_detail, "
+                   + "created_at, updated_at, status, profile_image_url"
+                   + ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+        try (
+            Connection conn = DBUtil.getConnection();
+            PreparedStatement pstmt = conn.prepareStatement(sql)
+        ) {
+            int newId = getNextMemberId();
+            dto.setMember_id(newId);
+
+            pstmt.setInt(1, dto.getMember_id());
+            pstmt.setInt(2, dto.getMatch_type_id() != null ? dto.getMatch_type_id() : 1);
+            pstmt.setString(3, dto.getEmail());
+            pstmt.setString(4, dto.getNickname());
+            pstmt.setString(5, dto.getPhone_number());
+            pstmt.setString(6, dto.getUser_type());
+            pstmt.setInt(7, dto.getPoint() != null ? dto.getPoint() : 0);
+            pstmt.setString(8, dto.getIntroduce_mento());
+            pstmt.setInt(9, dto.getScore() != null ? dto.getScore() : 0);
+            pstmt.setString(10, dto.getRegion_group());
+            pstmt.setString(11, dto.getRegion_subgroup());
+            pstmt.setString(12, dto.getRegion_detail());
+            pstmt.setDate(13, new java.sql.Date(System.currentTimeMillis()));
+            pstmt.setDate(14, null);
+            pstmt.setString(15, dto.getStatus());
+            pstmt.setString(16, dto.getProfile_image_url());
+
+            pstmt.executeUpdate();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private int getNextMemberId() {
+        int nextId = 1;
+        String sql = "SELECT NVL(MAX(member_id), 0) + 1 FROM member";
+        try (
+            Connection conn = DBUtil.getConnection();
+            Statement stmt = conn.createStatement();
+            ResultSet rs = stmt.executeQuery(sql)
+        ) {
+            if (rs.next()) {
+                nextId = rs.getInt(1);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return nextId;
+    }
+}

--- a/src/main/java/com/shinhan/memento/util/DBUtil.java
+++ b/src/main/java/com/shinhan/memento/util/DBUtil.java
@@ -1,0 +1,58 @@
+package com.shinhan.memento.util;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class DBUtil {
+	
+	public static Connection getConnection() {
+		Connection conn = null;
+		String url = "jdbc:oracle:thin:@localhost:1521:xe";
+		String userid = "memento", userpass = "memento";
+		
+		try {
+			Class.forName("oracle.jdbc.driver.OracleDriver");
+			conn = DriverManager.getConnection(url, userid, userpass);
+		} catch (SQLException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} catch (ClassNotFoundException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		
+		return conn;
+	}
+	
+	public static void dbDisconnect(
+			 Connection conn, Statement st, ResultSet rs) {
+		
+		try {
+			if(rs!=null) rs.close();
+			if(st!=null) st.close();
+			if(conn!=null) conn.close();
+			
+		} catch (SQLException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
+	
+	
+	public static String buildDebugSQL(String sqlTemplate, Object... params) {
+	    for (Object param : params) {
+	        String val = (param instanceof String) ? "'" + param + "'" : String.valueOf(param);
+	        sqlTemplate = sqlTemplate.replaceFirst("\\?", val);
+	    }
+	    return sqlTemplate;
+	}
+	
+}
+
+
+
+
+

--- a/src/main/webapp/WEB-INF/views/mainpage/login.jsp
+++ b/src/main/webapp/WEB-INF/views/mainpage/login.jsp
@@ -27,12 +27,10 @@
         </span>
       </span>
     </div>
+	<a class="div2" href="https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=dd889aeee45cfc71c810b8d5b41a800f&redirect_uri=http://localhost:9999/memento/api/auth/kakao/callback">
+	  <img src="${pageContext.request.contextPath}/resources/images/main1/kakaotalk.png" alt="카카오 로그인" />
+	</a>
 
-    <div class="button-image">
-      <button class="div2">
-        <img src="${pageContext.request.contextPath}/resources/images/main1/kakaotalk.png" alt="카카오 로그인" />
-      </button>
-    </div>
 
   </div>
 </div>

--- a/src/main/webapp/resources/css/mainpage/login.css
+++ b/src/main/webapp/resources/css/mainpage/login.css
@@ -89,14 +89,13 @@ html, body {
 .div2 {
   all: unset;
   border-radius: 10px;
-  width: 260px;
-  height: 50px;
   cursor: pointer;
+  margin-left :35px;
 }
 .div2 img {
-    width: 100%;
-    height: 100%;
+    width: 80%;
+    height: 13%;
     object-fit: cover;
     border-radius: 10px;
-    margin-top: 20px;
+    margin-top: 320px;
 }


### PR DESCRIPTION
## 요약 (Summary)
- `MEMBER` 테이블의 `EMAIL` 컬럼에 인덱스를 생성하여 검색 성능 기능 개선
-  가입하는 사용자의 카카오 프로필 사진,닉네임,이메일을 통해 '카카오 소셜 로그인' 구현 완료
- 회원가입/로그인 기능 구현 완료  

## 🔑 변경 사항 (Key Changes)
- `MEMBER` 테이블에 일반 인덱스 `IDX_MEMBER_EMAIL` 생성
- 회원과 비회원 구분을 위해 인덱스 처리& UNIQUE 제약 처리를 통해 구분 완료 

## ✅ 추가사항
SQL Developer에 아래와 같은 쿼리문 입력해주세요!
프로필 사진과 이메일 부분의 쿼리문 추가했습니다!

ALTER TABLE member ADD CONSTRAINT uq_member_email UNIQUE (email);
ALTER TABLE member ADD profile_image_url VARCHAR2(300);

CREATE INDEX MEMENTO.IDX_MEMBER_EMAIL
ON MEMENTO.MEMBER (EMAIL);