### PR TITLE
feat: 멘토스 신청 취소

### DIFF
--- a/src/main/java/com/shinhan/memento/common/exception/MemberMentosException.java
+++ b/src/main/java/com/shinhan/memento/common/exception/MemberMentosException.java
@@ -1,0 +1,22 @@
+package com.shinhan.memento.common.exception;
+
+import com.shinhan.memento.common.response.status.ResponseStatus;
+
+import lombok.Getter;
+
+@Getter
+public class MemberMentosException extends RuntimeException{
+
+    private final ResponseStatus exceptionStatus;
+
+    public MemberMentosException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+
+    public MemberMentosException(ResponseStatus exceptionStatus, String message) {
+        super(message);
+        this.exceptionStatus = exceptionStatus;
+    }
+
+}

--- a/src/main/java/com/shinhan/memento/common/exception_handler/MemberMentosExceptionControllerAdvice.java
+++ b/src/main/java/com/shinhan/memento/common/exception_handler/MemberMentosExceptionControllerAdvice.java
@@ -1,0 +1,22 @@
+package com.shinhan.memento.common.exception_handler;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.shinhan.memento.common.exception.MemberMentosException;
+import com.shinhan.memento.common.response.BaseErrorResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class MemberMentosExceptionControllerAdvice {
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MemberMentosException.class)
+    public BaseErrorResponse handle_MemberMentosExceptionn(MemberMentosException e) {
+        log.error("[handle_MemberMentosException]", e);
+        return new BaseErrorResponse(e.getExceptionStatus(), e.getMessage());
+    }
+}

--- a/src/main/java/com/shinhan/memento/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/shinhan/memento/common/response/status/BaseExceptionResponseStatus.java
@@ -34,12 +34,17 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
 	  /**
 	  * 6000 : mypage 관련 
 	  */
-	NEED_LOGIN(6000,HttpStatus.UNAUTHORIZED.value(), "로그인이 필요합니다.");
+	NEED_LOGIN(6000,HttpStatus.UNAUTHORIZED.value(), "로그인이 필요합니다."),
 
 		/**
 		* 7000 : 결제 관련?
 		*/ 
-
+	
+	/**
+	 * 8000 : member_mentos 관련 
+	 */
+	CANNOT_FOUND_MEMBER_MENTOS(8000, HttpStatus.BAD_REQUEST.value(), "해당 멘토스 참여기록을 찾을 수 없습니다.");
+	
     private final int code;
     private final int status;
     private final String message;

--- a/src/main/java/com/shinhan/memento/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/shinhan/memento/common/response/status/BaseExceptionResponseStatus.java
@@ -4,63 +4,63 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
-public enum BaseExceptionResponseStatus implements ResponseStatus{
+public enum BaseExceptionResponseStatus implements ResponseStatus {
 
-    /**
-     * 1000: 요청 성공 (OK)
-     */
-    SUCCESS(1000,HttpStatus.OK.value(), "요청에 성공하였습니다."),
-    FAILURE(2000, HttpStatus.BAD_REQUEST.value(), "요청에 실패하였습니다."),
-    
-    /**
-    * 3000 : member 관련
-    */
+	/**
+	 * 1000: 요청 성공 (OK)
+	 */
+	SUCCESS(1000, HttpStatus.OK.value(), "요청에 성공하였습니다."), FAILURE(2000, HttpStatus.BAD_REQUEST.value(), "요청에 실패하였습니다."),
 
-    CANNOT_FOUND_MEMBER(3000,HttpStatus.BAD_REQUEST.value(), "해당 유저를 찾을 수 없습니다."),
-    CANNOT_FOUND_MENTO(3001,HttpStatus.BAD_REQUEST.value(), "해당 멘토유저를 찾을 수 없습니다."),
-    
-    /**
-    * 4000 : mentos 관련
-    */
-	CANNOT_CREATE_MENTOS(4000,HttpStatus.BAD_REQUEST.value(), "멘토스를 개설할 수 없습니다. "),
-	CANNOT_EDIT_MENTOS(4001,HttpStatus.BAD_REQUEST.value(), "멘토스를 수정할 수 없습니다. "),
-	CANNOT_DElETE_MENTOS(4002,HttpStatus.BAD_REQUEST.value(), "멘토스를 삭제할 수 없습니다. "),
+	/**
+	 * 3000 : member 관련
+	 */
+
+	CANNOT_FOUND_MEMBER(3000, HttpStatus.BAD_REQUEST.value(), "해당 유저를 찾을 수 없습니다."),
+	CANNOT_FOUND_MENTO(3001, HttpStatus.BAD_REQUEST.value(), "해당 멘토유저를 찾을 수 없습니다."),
+
+	/**
+	 * 4000 : mentos 관련
+	 */
+	CANNOT_CREATE_MENTOS(4000, HttpStatus.BAD_REQUEST.value(), "멘토스를 개설할 수 없습니다. "),
+	CANNOT_EDIT_MENTOS(4001, HttpStatus.BAD_REQUEST.value(), "멘토스를 수정할 수 없습니다. "),
+	CANNOT_DElETE_MENTOS(4002, HttpStatus.BAD_REQUEST.value(), "멘토스를 삭제할 수 없습니다. "),
 	CANNOT_JOIN_MENTOS(4003, HttpStatus.BAD_REQUEST.value(), "멘토스 참여에 실패했습니다."),
 	CANNOT_FOUND_MENTOS(4004, HttpStatus.BAD_REQUEST.value(), "해당 멘토스를 찾을 수 없습니다."),
-	  /**
-	  * 5000 : keepgoing 관련
-	  */
-	  
-	  /**
-	  * 6000 : mypage 관련 
-	  */
-	NEED_LOGIN(6000,HttpStatus.UNAUTHORIZED.value(), "로그인이 필요합니다."),
-
-		/**
-		* 7000 : 결제 관련?
-		*/ 
-	
 	/**
-	 * 8000 : member_mentos 관련 
+	 * 5000 : keepgoing 관련
 	 */
-	CANNOT_FOUND_MEMBER_MENTOS(8000, HttpStatus.BAD_REQUEST.value(), "해당 멘토스 참여기록을 찾을 수 없습니다.");
-	
-    private final int code;
-    private final int status;
-    private final String message;
 
-    @Override
-    public int getCode() {
-        return code;
-    }
+	/**
+	 * 6000 : mypage 관련
+	 */
+	NEED_LOGIN(6000, HttpStatus.UNAUTHORIZED.value(), "로그인이 필요합니다."),
 
-    @Override
-    public int getStatus() {
-        return status;
-    }
+	/**
+	 * 7000 : 결제 관련?
+	 */
 
-    @Override
-    public String getMessage() {
-        return message;
-    }
+	/**
+	 * 8000 : member_mentos 관련
+	 */
+	CANNOT_FOUND_MEMBER_MENTOS(8000, HttpStatus.BAD_REQUEST.value(), "해당 멘토스 참여기록을 찾을 수 없습니다."),
+	CANNOT_CANCEL_MEMBER_MENTOS(8001, HttpStatus.BAD_REQUEST.value(), "멘토스 참여취소에 실패했습니다.");
+
+	private final int code;
+	private final int status;
+	private final String message;
+
+	@Override
+	public int getCode() {
+		return code;
+	}
+
+	@Override
+	public int getStatus() {
+		return status;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
 }

--- a/src/main/java/com/shinhan/memento/mapper/MemberMentosMapper.java
+++ b/src/main/java/com/shinhan/memento/mapper/MemberMentosMapper.java
@@ -3,9 +3,12 @@ package com.shinhan.memento.mapper;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.shinhan.memento.dto.JoinMentosDTO;
+import com.shinhan.memento.model.MemberMentos;
 
 @Mapper
 public interface MemberMentosMapper {
 	
-	int joinMentos(JoinMentosDTO joinMentosId);
+	int joinMentos(JoinMentosDTO joinMentosDTO);
+	MemberMentos findMemberMentosById(JoinMentosDTO joinMentosDTO);
+	int cancelJoinMentos(int memberMentosId);
 }

--- a/src/main/java/com/shinhan/memento/service/MemberMentosService.java
+++ b/src/main/java/com/shinhan/memento/service/MemberMentosService.java
@@ -1,0 +1,27 @@
+package com.shinhan.memento.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.shinhan.memento.dto.JoinMentosDTO;
+import com.shinhan.memento.mapper.MemberMentosMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class MemberMentosService {
+
+	@Autowired
+	MemberMentosMapper memberMentosMapper;
+
+	/**
+	 * 멘토스 참여하기(신청하기)
+	 */
+	@Transactional
+	public int joinMentos(JoinMentosDTO joinMentoDto) {
+		log.info("[MentosService.joinMentos]");
+		return memberMentosMapper.joinMentos(joinMentoDto);
+	}
+}

--- a/src/main/java/com/shinhan/memento/service/MemberMentosService.java
+++ b/src/main/java/com/shinhan/memento/service/MemberMentosService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.shinhan.memento.dto.JoinMentosDTO;
 import com.shinhan.memento.mapper.MemberMentosMapper;
+import com.shinhan.memento.model.MemberMentos;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -21,7 +22,22 @@ public class MemberMentosService {
 	 */
 	@Transactional
 	public int joinMentos(JoinMentosDTO joinMentoDto) {
-		log.info("[MentosService.joinMentos]");
+		log.info("[MemberMentosService.joinMentos]");
 		return memberMentosMapper.joinMentos(joinMentoDto);
+	}
+	
+	// memberId, mentosId 로 유효한 member_mentos 가 있는지 확인 
+	public MemberMentos checkValidMemberMentos(JoinMentosDTO joinMentoDto) {
+		log.info("[MemberMentosService.checkValidMemberMentos]");
+		return memberMentosMapper.findMemberMentosById(joinMentoDto);
+	}
+	
+	/**
+	 * 멘토스 참여 취소(신청 취소하기)
+	 */
+	@Transactional
+	public int cancelJoinMentos(int memberMentosId) {
+		log.info("[MemberMentosService.cancelJoinMentos]");
+		return memberMentosMapper.cancelJoinMentos(memberMentosId);
 	}
 }

--- a/src/main/java/com/shinhan/memento/service/MentosService.java
+++ b/src/main/java/com/shinhan/memento/service/MentosService.java
@@ -34,109 +34,86 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 public class MentosService {
 
-    @Autowired
-    MentosMapper mentosMapper;
-    
-    @Autowired
-    MemberMentosMapper memberMentosMapper;
+	@Autowired
+	MentosMapper mentosMapper;
 
-    @Value("${file.upload.dir}")
-    private String uploadDir;
+	@Value("${file.upload.dir}")
+	private String uploadDir;
 
-    public Mentos checkValidMentosById(int mentosId) {
-    	log.info("MentosService.checkValidMentosById");
-    	return mentosMapper.checkValidMentosById(mentosId);
-    }
-    
-    @Transactional
-    public boolean createMentos(CreateMentosDTO requestDto, MultipartFile imageFile) {
-        log.info("[MentosService.createMentos]");
+	public Mentos checkValidMentosById(int mentosId) {
+		log.info("MentosService.checkValidMentosById");
+		return mentosMapper.checkValidMentosById(mentosId);
+	}
 
-        // 날짜 및 시간 변환
-        Date startDay = Date.valueOf(requestDto.getStartDay());
-        Date endDay = Date.valueOf(requestDto.getEndDay());
-        Timestamp startTime = Timestamp.valueOf(LocalDateTime.of(LocalDate.of(2000, 1, 1), LocalTime.parse(requestDto.getStartTime())));
-        Timestamp endTime = Timestamp.valueOf(LocalDateTime.of(LocalDate.of(2000, 1, 1), LocalTime.parse(requestDto.getEndTime())));
+	@Transactional
+	public boolean createMentos(CreateMentosDTO requestDto, MultipartFile imageFile) {
+		log.info("[MentosService.createMentos]");
 
-        // 이미지 저장 처리
-        String imageUrl = null;
-        if (imageFile != null && !imageFile.isEmpty()) {
-            try {
-                File dir = new File(uploadDir);
-                if (!dir.exists()) {
-                    dir.mkdirs();
-                }
+		// 날짜 및 시간 변환
+		Date startDay = Date.valueOf(requestDto.getStartDay());
+		Date endDay = Date.valueOf(requestDto.getEndDay());
+		Timestamp startTime = Timestamp
+				.valueOf(LocalDateTime.of(LocalDate.of(2000, 1, 1), LocalTime.parse(requestDto.getStartTime())));
+		Timestamp endTime = Timestamp
+				.valueOf(LocalDateTime.of(LocalDate.of(2000, 1, 1), LocalTime.parse(requestDto.getEndTime())));
 
-                // 확장자 추출 + 고유 파일명 생성
-                String ext = getFileExtension(imageFile.getOriginalFilename());
-                String savedFileName = UUID.randomUUID().toString() + (ext != null ? "." + ext : "");
-                File destFile = new File(dir, savedFileName);
-                Files.copy(imageFile.getInputStream(), destFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+		// 이미지 저장 처리
+		String imageUrl = null;
+		if (imageFile != null && !imageFile.isEmpty()) {
+			try {
+				File dir = new File(uploadDir);
+				if (!dir.exists()) {
+					dir.mkdirs();
+				}
 
-                // 웹에서 접근 가능한 경로로 구성 (리소스 경로 기준)
-                imageUrl = "/resources/uploadImage/" + savedFileName;
-                log.info("이미지 저장 완료: {}", imageUrl);
-            } catch (IOException e) {
-                log.error("이미지 업로드 실패", e);
-                return false;
-            }
-        }
+				// 확장자 추출 + 고유 파일명 생성
+				String ext = getFileExtension(imageFile.getOriginalFilename());
+				String savedFileName = UUID.randomUUID().toString() + (ext != null ? "." + ext : "");
+				File destFile = new File(dir, savedFileName);
+				Files.copy(imageFile.getInputStream(), destFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
 
-        // DB 저장용 DTO 생성
-        CreateMentosDBDTO dbDTO = CreateMentosDBDTO.builder()
-                .categoryId(requestDto.getCategoryId())
-                .content(requestDto.getContent())
-                .endDay(endDay)
-                .startDay(startDay)
-                .endTime(endTime)
-                .startTime(startTime)
-                .image(imageUrl) // URL 경로 저장
-                .languageId(requestDto.getLanguageId())
-                .matchTypeFirst(requestDto.getMatchTypeFirst())
-                .matchTypeSecond(requestDto.getMatchTypeSecond())
-                .matchTypeThird(requestDto.getMatchTypeThird())
-                .maxMember(requestDto.getMaxMember())
-                .minMember(requestDto.getMinMember())
-                .price(requestDto.getPrice())
-                .mentoId(requestDto.getMentoId())
-                .title(requestDto.getTitle())
-                .simpleContent(requestDto.getSimpleContent())
-                .selectedDays(requestDto.getSelectedDays())
-                .times(requestDto.getTimes())
-                .regionDetail(requestDto.getRegionDetail())
-                .regionGroup(requestDto.getRegionGroup())
-                .regionSubgroup(requestDto.getRegionSubgroup())
-                .build();
+				// 웹에서 접근 가능한 경로로 구성 (리소스 경로 기준)
+				imageUrl = "/resources/uploadImage/" + savedFileName;
+				log.info("이미지 저장 완료: {}", imageUrl);
+			} catch (IOException e) {
+				log.error("이미지 업로드 실패", e);
+				return false;
+			}
+		}
 
-        int result = mentosMapper.createMentos(dbDTO);
-        return result == 1;
-    }
+		// DB 저장용 DTO 생성
+		CreateMentosDBDTO dbDTO = CreateMentosDBDTO.builder().categoryId(requestDto.getCategoryId())
+				.content(requestDto.getContent()).endDay(endDay).startDay(startDay).endTime(endTime)
+				.startTime(startTime).image(imageUrl) // URL 경로 저장
+				.languageId(requestDto.getLanguageId()).matchTypeFirst(requestDto.getMatchTypeFirst())
+				.matchTypeSecond(requestDto.getMatchTypeSecond()).matchTypeThird(requestDto.getMatchTypeThird())
+				.maxMember(requestDto.getMaxMember()).minMember(requestDto.getMinMember()).price(requestDto.getPrice())
+				.mentoId(requestDto.getMentoId()).title(requestDto.getTitle())
+				.simpleContent(requestDto.getSimpleContent()).selectedDays(requestDto.getSelectedDays())
+				.times(requestDto.getTimes()).regionDetail(requestDto.getRegionDetail())
+				.regionGroup(requestDto.getRegionGroup()).regionSubgroup(requestDto.getRegionSubgroup()).build();
 
-    private String getFileExtension(String fileName) {
-        if (fileName != null && fileName.contains(".")) {
-            return fileName.substring(fileName.lastIndexOf('.') + 1);
-        }
-        return null;
-    }
+		int result = mentosMapper.createMentos(dbDTO);
+		return result == 1;
+	}
 
-    public List<LanguageDTO> getAllLanguages() {
-        return mentosMapper.getAllLanguages();
-    }
+	private String getFileExtension(String fileName) {
+		if (fileName != null && fileName.contains(".")) {
+			return fileName.substring(fileName.lastIndexOf('.') + 1);
+		}
+		return null;
+	}
 
-    public List<CategoryDTO> getAllCategories() {
-        return mentosMapper.getAllCategories();
-    }
+	public List<LanguageDTO> getAllLanguages() {
+		return mentosMapper.getAllLanguages();
+	}
 
-    public List<MatchTypeDTO> getAllMatchTypes() {
-        return mentosMapper.getAllMatchTypes();
-    }
-    
-    /**
-     * 멘토스 참여하기(신청하기)
-     */
-    @Transactional
-    public int joinMentos(JoinMentosDTO joinMentoDto) {
-    	log.info("[MentosService.joinMentos]");
-    	return memberMentosMapper.joinMentos(joinMentoDto);
-    }
+	public List<CategoryDTO> getAllCategories() {
+		return mentosMapper.getAllCategories();
+	}
+
+	public List<MatchTypeDTO> getAllMatchTypes() {
+		return mentosMapper.getAllMatchTypes();
+	}
+
 }

--- a/src/main/java/com/shinhan/memento/service/TestService.java
+++ b/src/main/java/com/shinhan/memento/service/TestService.java
@@ -1,6 +1,0 @@
-package com.shinhan.memento.service;
-
-public class TestService {
-
-	String test;
-}

--- a/src/main/resources/Mybatis/mappers/MemberMentosMapper.xml
+++ b/src/main/resources/Mybatis/mappers/MemberMentosMapper.xml
@@ -2,12 +2,41 @@
 <!DOCTYPE mapper
   PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-  
- <mapper namespace="com.shinhan.memento.mapper.MemberMentosMapper">
- 
- 	<insert id="joinMentos" parameterType="com.shinhan.memento.dto.JoinMentosDTO">
- 		insert into member_mentos(member_mentos_id, mentos_id, member_id, is_compeleted, created_at, updated_at, status)
- 		values(seq_member_mentos_id.nextval, #{mentosId}, #{memberId}, 0, sysdate, null, 'ACTIVE')
- 	</insert>
- 
- </mapper>
+
+<mapper namespace="com.shinhan.memento.mapper.MemberMentosMapper">
+
+	<resultMap id="MemberMentosResultMap"
+		type="com.shinhan.memento.model.MemberMentos">
+		<id property="memberMentosId" column="member_mentos_id" />
+		<result property="mentosId" column="mentos_id" />
+		<result property="memberId" column="member_id" />
+		<result property="createdAt" column="created_at"/>
+		<result property="updatedAt" column="updated_at"/>
+		<result property="status" column="status" />
+	</resultMap>
+
+		<insert id="joinMentos"
+			parameterType="com.shinhan.memento.dto.JoinMentosDTO">
+			insert into member_mentos(member_mentos_id, mentos_id, member_id,
+			is_compeleted, created_at, updated_at, status)
+			values(seq_member_mentos_id.nextval, #{mentosId}, #{memberId}, 0,
+			sysdate, null, 'ACTIVE')
+		</insert>
+
+		<select id="findMemberMentosById"
+			parameterType="com.shinhan.memento.dto.JoinMentosDTO"
+			resultMap="MemberMentosResultMap">
+			select *
+			from member_mentos
+			where mentos_id=#{mentosId}
+			and member_id=#{memberId}
+			and status='ACTIVE'
+		</select>
+
+		<update id="cancelJoinMentos" parameterType="int">
+			update member_mentos
+			set status='DELETE', updated_at=sysdate
+			where member_mentos_id=#{memberMentosId} and status='ACTIVE'
+		</update>
+
+</mapper>


### PR DESCRIPTION
## 요약 (Summary)
- [x] 멘토스 신청 취소하는 백엔드 api 구현했습니다(프론트는 나중에 연결할게요)

## 확인 방법 
```
select * from member_mentos;
```
로 status = ACTIVE 인 member_id , mentos_id 가 필요합니다.(없다면 이전 멘토스 신청 pr 에서 하나 만들어주세요)
그 member_id, mentos_id 를 가지고 postman 에서 아래의 주소로 `Patch` 요청 보내주세요!

```
http://localhost:9999/memento/mentos/join/cancel
```

다음과 같이 요청이 성공한 것을 확인할 수 있습니다.
<img width="1067" alt="스크린샷 2025-07-02 11 37 28" src="https://github.com/user-attachments/assets/e59431b9-2ef7-4403-9b45-edd2568e94c5" />
<img width="839" alt="스크린샷 2025-07-02 11 37 43" src="https://github.com/user-attachments/assets/c8d865dc-8967-48b5-9040-5188687ff78f" />

DB 도 잘 바뀌어있는 것을 확인할 수 있습니다.

<img width="839" alt="스크린샷 2025-07-02 11 38 23" src="https://github.com/user-attachments/assets/25961157-d492-4244-a01f-ccb404b83bf4" />

DB 에 없는 값을 요청보내면 다음과 같이 예외처리 해두었습니다!