### PR TITLE
feat: 매치업 신청하기 기능 구현

### DIFF
--- a/src/main/java/com/shinhan/memento/controller/MatchupController.java
+++ b/src/main/java/com/shinhan/memento/controller/MatchupController.java
@@ -21,6 +21,7 @@ import com.shinhan.memento.common.response.status.BaseExceptionResponseStatus;
 import com.shinhan.memento.dto.CategoryDTO;
 import com.shinhan.memento.dto.LanguageDTO;
 import com.shinhan.memento.dto.MatchTypeDTO;
+import com.shinhan.memento.dto.MatchupApplyMentiDTO;
 import com.shinhan.memento.dto.MatchupApplyMentoDTO;
 import com.shinhan.memento.dto.MatchupApproveMentoDTO;
 import com.shinhan.memento.dto.MatchupCreateDTO;
@@ -40,6 +41,37 @@ public class MatchupController {
    
    @Autowired
    MatchupService matchupService;
+
+   /* 특정 매치업에 멘티로 신청하기 */
+   @PostMapping("/applyMentiMatchup")
+   @ResponseBody
+   public BaseResponse<String> applyMentiMatchup(@RequestBody MatchupApplyMentiDTO dto, HttpSession session) {
+       try {
+           Member loginUser = (Member) session.getAttribute("loginUser");
+           if (loginUser == null) {
+               return new BaseResponse<>(BaseExceptionResponseStatus.FAILURE, "로그인이 필요합니다.");
+           }
+           dto.setMemberId(loginUser.getMemberId());
+
+           int result = matchupService.applyForMatchupAsMenti(dto);
+
+           switch (result) {
+               case 1:
+                   return new BaseResponse<>(BaseExceptionResponseStatus.SUCCESS, "매치업 참여 신청이 완료되었습니다.");
+               case -1:
+                   return new BaseResponse<>(BaseExceptionResponseStatus.FAILURE, "모집 인원이 모두 찼습니다.");
+               case -2:
+                   return new BaseResponse<>(BaseExceptionResponseStatus.FAILURE, "이미 신청한 매치업입니다.");
+               case -3:
+                   return new BaseResponse<>(BaseExceptionResponseStatus.FAILURE, "존재하지 않는 매치업입니다.");
+               default:
+                   return new BaseResponse<>(BaseExceptionResponseStatus.FAILURE, "신청에 실패했습니다. 다시 시도해주세요.");
+           }
+       } catch (Exception e) {
+           e.printStackTrace();
+           return new BaseResponse<>(BaseExceptionResponseStatus.FAILURE, "서버 오류로 신청에 실패했습니다.");
+       }
+   }
    
    /* 멘토 승인 요청 처리 API */
    @PostMapping("/approveMento")

--- a/src/main/java/com/shinhan/memento/dao/MatchUpDAO.java
+++ b/src/main/java/com/shinhan/memento/dao/MatchUpDAO.java
@@ -137,4 +137,9 @@ public class MatchUpDAO {
    public MatchupWaitingMentoDTO getApprovedMentoDetails(int memberId) {
        return sqlSession.selectOne(namespace + "getApprovedMentoDetails", memberId);
    }
+   
+   /* 매치업 현재 인원 1 증가 */
+   public int incrementMatchupCount(int matchupId) {
+       return sqlSession.update(namespace + "incrementMatchupCount", matchupId);
+   }
 }

--- a/src/main/java/com/shinhan/memento/dao/MemberMatchUpDAO.java
+++ b/src/main/java/com/shinhan/memento/dao/MemberMatchUpDAO.java
@@ -3,11 +3,13 @@ package com.shinhan.memento.dao;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.ibatis.session.SqlSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
+import com.shinhan.memento.dto.MatchupApplyMentiDTO;
 import com.shinhan.memento.dto.MyMatchupListResponseDTO;
 
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +20,7 @@ public class MemberMatchUpDAO {
 	
 	@Autowired
 	SqlSession sqlSession;
-	String namespace = "com.shinhan.memento.dao.MatchUpDAO.";
+	String namespace = "com.shinhan.memento.dao.MemberMatchUpDAO.";
 	
 	String mypageNamespace="com.memento.shinhan.mymatchuplist.";
 	
@@ -47,11 +49,19 @@ public class MemberMatchUpDAO {
         return memberMatchUPList;
 	}
 	
-	
-	/* 삭제된 매치업에 신청 혹은 참여중인 멤버 데이터 삭제하기 */
-	public int inactivateMemberMatchupById(int matchupId) {
-		return sqlSession.delete(namespace + "inactivateMemberMatchupById", matchupId);
-
-	}
+	/* 매치업에 멘티로 신청 */
+    public int applyAsMenti(MatchupApplyMentiDTO dto) {
+        return sqlSession.insert(namespace + "applyAsMenti", dto);
+    }
+    
+    /* 특정 유저가 특정 매치업에 이미 신청했는지 확인 */
+    public int checkIfAlreadyApplied(Map<String, Object> params) {
+        return sqlSession.selectOne(namespace + "checkIfAlreadyApplied", params);
+    }
+    
+    /* 매치업 비활성화 시 멤버들도 비활성화 */
+    public int inactivateMemberMatchupById(int matchupId) {
+        return sqlSession.update(namespace + "inactivateMemberMatchupById", matchupId);
+    }
 
 }

--- a/src/main/java/com/shinhan/memento/dto/MatchupApplyMentiDTO.java
+++ b/src/main/java/com/shinhan/memento/dto/MatchupApplyMentiDTO.java
@@ -1,0 +1,15 @@
+package com.shinhan.memento.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+public class MatchupApplyMentiDTO {
+    private Integer matchupId;
+    private Integer memberId;
+}

--- a/src/main/java/com/shinhan/memento/dto/MatchupDetailDTO.java
+++ b/src/main/java/com/shinhan/memento/dto/MatchupDetailDTO.java
@@ -57,11 +57,14 @@ public class MatchupDetailDTO {
 	    /* 모집 현황 정보 */
 	    String mRecruit; 		/* 멘토를 모집하는 매치업인가에 대한 여부 (멘토 모집중, 모집 완료(표시 안됨))*/ 
 	   
-	    boolean isMentoApplicationPending; 	/* 현재 유저의 해당 매치업 멘토 신청 상태 */
+	    boolean isMentoApplicationPending; 	/* 현재 유저의 해당 매치업 멘토 신청 상태 */    
+
+	    @Builder.Default 
+	    private boolean AlreadyAppliedAsMenti = false; /* 현재 유저가 해당 매치업 멘티 참여 여부 상태 */
 	    
 	    /* 선정된 멘토의 정보를 담을 필드 */
 	    private String mentoNickname;
-	    private String mentoProfileImageUrl;
+	    private String mentoProfileImageUrl;	    	    
 	    
 	   	/* 날짜 포맷 변경 */
 	    public String getFormattedStartDate() {

--- a/src/main/java/com/shinhan/memento/util/DBUtil.java
+++ b/src/main/java/com/shinhan/memento/util/DBUtil.java
@@ -10,7 +10,7 @@ public class DBUtil {
 	
 	public static Connection getConnection() {
 		Connection conn = null;
-		String url = "jdbc:oracle:thin:@localhost:1521/XEPDB1";
+		String url = "jdbc:oracle:thin:@localhost:1521:XE";
 		String userid = "memento", userpass = "memento";
 		
 		try {

--- a/src/main/resources/Mybatis/mappers/matchupMapper.xml
+++ b/src/main/resources/Mybatis/mappers/matchupMapper.xml
@@ -62,10 +62,17 @@
    </resultMap>
 
    <resultMap id="matchupModelResultMap" type="com.shinhan.memento.model.MatchUp">
-       <id property="matchupId" column="matchup_id"/>
-       <result property="categoryId" column="category_id"/>
-       <result property="languageId" column="language_id"/>
-       <result property="leaderId" column="leader_id"/>
+		<id property="matchupId" column="matchup_id"/>
+		<result property="categoryId" column="category_id"/>
+		<result property="languageId" column="language_id"/>
+		<result property="leaderId" column="leader_id"/>
+		<result property="minMember" column="min_member"/>
+		<result property="maxMember" column="max_member"/>
+		<result property="title" column="title"/>
+		<result property="content" column="content"/>
+		<result property="hasMento" column="has_mento"/>
+		<result property="price" column="price"/>
+		<result property="status" column="status"/>
     </resultMap>
 
    <select id="getMatchupModelById" parameterType="int" resultMap="matchupModelResultMap">
@@ -304,13 +311,7 @@
            'ACTIVE'
        )
    </insert>
-
-   <update id="inactivateMemberMatchupById" parameterType="int">
-      UPDATE
-      MEMBER_MATCHUP
-      SET status = 'INACTIVE'
-      WHERE MATCHUP_ID = #{matchupId}
-   </update>
+   
    <update id="inactivateMatchupByIdAndLeader" parameterType="map">
       UPDATE MATCHUP
       SET status = 'INACTIVE',
@@ -473,5 +474,12 @@
     WHERE
         MEMBER_ID = #{memberId}
 	</select>
+
+    <update id="incrementMatchupCount" parameterType="int">
+        UPDATE matchup
+        SET matchup_count = matchup_count + 1,
+            updated_at = SYSDATE
+        WHERE matchup_id = #{matchupId}
+    </update>
     
 </mapper>

--- a/src/main/resources/Mybatis/mappers/memberMatchupMapper.xml
+++ b/src/main/resources/Mybatis/mappers/memberMatchupMapper.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.shinhan.memento.dao.MemberMatchUpDAO">
+
+    <insert id="applyAsMenti" parameterType="com.shinhan.memento.dto.MatchupApplyMentiDTO">
+        INSERT INTO member_matchup (
+            member_matchup_id,
+            member_id,
+            matchup_id,
+            status,
+            created_at,
+            updated_at
+        ) VALUES (
+            SEQ_MEMBER_MATCHUP_ID.NEXTVAL,
+            #{memberId},
+            #{matchupId},
+            'ACTIVE',
+            SYSDATE,
+            SYSDATE
+        )
+    </insert>
+    
+    <select id="checkIfAlreadyApplied" parameterType="map" resultType="int">
+        SELECT COUNT(*)
+        FROM member_matchup
+        WHERE member_id = #{memberId}
+        AND matchup_id = #{matchupId}
+        AND status = 'ACTIVE'
+    </select>
+    
+	<update id="inactivateMemberMatchupById" parameterType="int">
+		UPDATE MEMBER_MATCHUP
+		SET status = 'INACTIVE'
+		WHERE MATCHUP_ID = #{matchupId}
+	</update>
+
+</mapper>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.datasource.password=YOUR_DB_PASSWORD
 spring.datasource.driver-class-name=oracle.jdbc.driver.OracleDriver
 
 # MyBatis \uC124\uC815
-mybatis.mapper-locations=classpath*:mapper/*.xml
+mybatis.mapper-locations=classpath*:mappers/*.xml
 mybatis.type-aliases-package=com.shinhan.memento.dto
 
 # \uCE74\uBA5C\uCF00\uC774\uC2A4 \uC790\uB3D9 \uB9E4\uD551 \uD65C\uC131\uD654 (\uCEEC\uB7FC\uBA85\uACFC DTO \uD544\uB4DC\uBA85\uC774 \uB2E4\uB978 \uACBD\uC6B0 \uC790\uB3D9 \uBCC0\uD658)

--- a/src/main/webapp/resources/css/matchupDetail.css
+++ b/src/main/webapp/resources/css/matchupDetail.css
@@ -300,6 +300,13 @@ html, body {
   gap: 8px;
 }
 
+.button-area .apply-btn.applied {
+    background-color: #6c757d; /* 회색 계열 */
+    border-color: #6c757d;
+    color: white;
+    cursor: not-allowed; /* 마우스 커서 변경 */
+}
+
 .rectangle-298 {
 	background: #0070d1;
 	border-radius: 10px;

--- a/target/m2e-wtp/web-resources/META-INF/MANIFEST.MF
+++ b/target/m2e-wtp/web-resources/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
-Built-By: hyeon
-Build-Jdk: 11.0.27
+Built-By: fzaca
+Build-Jdk: 11.0.0.1
 Created-By: Maven Integration for Eclipse
+


### PR DESCRIPTION
## 요약 (Summary)
- 멘티로 매치업 신청하기 기능 추가

## 🔑 변경 사항 (Key Changes)

<수정>
- MatchupController
- MatchupService
- MatchUpDAO
- matchupMapper
- memberMatchupMapper

<추가>
- MatchupApplyMentiDTO.java

## 📝 리뷰 요구사항 (To Reviewers)

- 해당 매치업의 방장이 아닌 경우 참여하기 버튼이 잘 노출되는가.
- 참여하기 버튼 클릭 시 신청 완료로 이어지는가.
- matchup 테이블의 해당 matchup_id의 조건으로 필터 시 matchup_count에 1이 가산되는가.
- member_matchup 테이블의 해당 회원의 데이터와 matchup_id 값이 매핑 및 추가되는가.

## 확인 방법 
