### PR TITLE
feat : 매치업 생성, 수정 페이지 소개글 스마트 에디터로 변경 완료

### DIFF
--- a/src/main/webapp/WEB-INF/views/matchup/createMatchup.jsp
+++ b/src/main/webapp/WEB-INF/views/matchup/createMatchup.jsp
@@ -8,9 +8,10 @@
 <meta charset="UTF-8">
 <title>me:mento</title>
 <link rel="stylesheet" href="${cpath}/resources/css/createMatchup.css">
-<link rel="stylesheet" href="${cpath}/resources/css/vars.css">
+
 <script
     src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+    <script src="${cpath}/resources/smarteditor2/js/service/HuskyEZCreator.js" charset="utf-8"></script>
 </head>
 <body>
 	<%@ include file="../common/logout_header.jsp"%>
@@ -31,15 +32,15 @@
 	            </div>
 	        </div>
 	
-	        <div class="content-area">
-	            <div class="form-label-wrapper">
-	                <div class="form-label">소개글</div>
-	            </div>
-	            <div class="input-container textarea-container">
-	                <div id="matchupContent" class="editable-title" contenteditable="true" data-placeholder="활동 중심으로 소개해주세요. 소개를 잘 작성한 매치업은 2배 많은 인원이 가입해요!"></div>
-	                <input type="hidden" id="matchupContentHidden" name="matchupContent" value="">
-	            </div>
-	        </div>
+			<div class="content-area">
+			  <div class="form-label-wrapper">
+			    <div class="form-label">소개글</div>
+			  </div>
+			  <div class="input-container textarea-container">
+			     <textarea id="matchupContent" name="matchupContent">
+			    </textarea>
+			  </div>
+			</div>
 	
 	        <div class="address-area-wrapper">
 	            <div class="form-label-wrapper">
@@ -184,5 +185,16 @@
    window.cpath = '${cpath}';
 </script>    
 <script src="${cpath}/resources/js/matchup/createMatchup.js"></script>
+
+<script type="text/javascript">
+  var oEditors = [];
+
+  nhn.husky.EZCreator.createInIFrame({
+    oAppRef: oEditors,
+    elPlaceHolder: "matchupContent",  // textarea id
+    sSkinURI: cpath + "/resources/smarteditor2/SmartEditor2Skin.html",
+    fCreator: "createSEditor2"
+  });
+</script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/matchup/updateMatchup.jsp
+++ b/src/main/webapp/WEB-INF/views/matchup/updateMatchup.jsp
@@ -11,6 +11,7 @@
 <link rel="stylesheet" href="${cpath}/resources/css/vars.css">
 <script
     src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+<script src="${cpath}/resources/smarteditor2/js/service/HuskyEZCreator.js" charset="utf-8"></script>
 </head>
 <body>
     <jsp:include page="/WEB-INF/views/matchup/updateConfirmModal.jsp" />
@@ -35,7 +36,7 @@
                 <div class="form-label">소개글</div>
             </div>
             <div class="input-container textarea-container">
-                <div id="matchupContent" class="editable-title" contenteditable="true" data-placeholder="활동 중심으로 소개해주세요.">${matchupDetail.content}</div>
+				<textarea id="matchupContent" name="content" rows="10" cols="100" style="width:100%;">${matchupDetail.content}</textarea>
             </div>
         </div>
 
@@ -179,5 +180,18 @@
         };
     </script>    
     <script src="${cpath}/resources/js/matchup/updateMatchup.js?v=<%= new java.util.Date().getTime() %>"></script>
+<script>
+  const cpath = '${cpath}';  // 이거 꼭 있어야 함!
+</script>
+<script type="text/javascript">
+  var oEditors = [];
+
+  nhn.husky.EZCreator.createInIFrame({
+    oAppRef: oEditors,
+    elPlaceHolder: "matchupContent",  // textarea id
+    sSkinURI: cpath + "/resources/smarteditor2/SmartEditor2Skin.html",
+    fCreator: "createSEditor2"
+  });
+</script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/mentos/mentosCreate.jsp
+++ b/src/main/webapp/WEB-INF/views/mentos/mentosCreate.jsp
@@ -268,6 +268,18 @@
 							},
 							fCreator : "createSEditor2"
 						});
+
+				// SmartEditor 내용과 함께 폼 제출을 처리하는 새로운 함수
+				function submitMentosForm() {
+					// 이 줄은 SmartEditor에게 'editorTxt' textarea로 내용을 다시 쓰라고 지시합니다.
+					oEditors.getById["editorTxt"].exec("UPDATE_CONTENTS_FIELD", []);
+
+					// 이제 프로그래밍 방식으로 폼을 제출할 수 있습니다.
+					// 폼에 대한 참조를 가져와야 합니다. 폼에 ID가 없다면 ID를 부여하거나,
+					// 페이지에 폼이 하나뿐이라면 태그 이름으로 선택할 수 있습니다.
+					// 예를 들어, <form> 태그에 id="mentosCreateForm"을 추가했다면:
+					document.querySelector('form').submit(); // 또는 document.getElementById('mentosCreateForm').submit();
+				}
 			</script>
 		</form>
 	</section>

--- a/src/main/webapp/resources/css/createMatchup.css
+++ b/src/main/webapp/resources/css/createMatchup.css
@@ -108,11 +108,6 @@ body {
     align-items: center;
 }
 
-.textarea-container {
-    padding: 16px 23px;
-    min-height: 200px; /* 높이 조정 */
-    align-items: flex-start;
-}
 
 .input-placeholder-text { /* .div3, ._2 등을 대체 */
     color: #b0b0b0;
@@ -159,6 +154,13 @@ body {
     height: 55px;
     font-size: 16px;
     color: #333;
+}
+
+.input-container.textarea-container {
+    border: none !important;
+    padding: 0 !important;
+    min-height: unset !important;
+    display: block !important;
 }
 
 .postal-code-btn {
@@ -219,12 +221,14 @@ body {
     height: 52px;
     width: 100%;
     cursor: pointer;
+    
 }
 
 .selected-value-text { /* .java, .div7 등을 대체 */
-    color: #000000;
+    color: #333;
     font-size: 18px;
     font-weight: 500;
+    text-align: center;
 }
 
 .dropdown-arrow-icon { /* .icon-caret-05 */

--- a/src/main/webapp/resources/js/matchup/createMatchup.js
+++ b/src/main/webapp/resources/js/matchup/createMatchup.js
@@ -101,13 +101,22 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     setupEditableContent('matchupTitle', 'matchupTitleHidden', 30);
-    setupEditableContent('matchupContent', 'matchupContentHidden', 500);
+    // setupEditableContent('matchupContent', 'matchupContentHidden', 500);
     
 
     // 매치업 생성 AJAX 요청
     const createBtn = document.getElementById('createMatchupBtn');
     if (createBtn) {
         createBtn.addEventListener('click', function() {
+         // SmartEditor2 값 업데이트
+         
+			if (window.oEditors && oEditors.getById && oEditors.getById["matchupContent"]) {
+			    oEditors.getById["matchupContent"].exec("UPDATE_CONTENTS_FIELD", []);
+			} else {
+			    alert("에디터가 아직 준비되지 않았습니다. 잠시 후 다시 시도해주세요.");
+			    return;
+			}
+        	
             const startDate = document.querySelector('input[name="startDate"]').value;
             const startTime = document.querySelector('input[name="startTime"]').value;
             const endDate = document.querySelector('input[name="endDate"]').value;
@@ -126,7 +135,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 matchupCount: 0,
                 kgCount: 0,
                 title: document.getElementById('matchupTitleHidden').value,
-                content: document.getElementById('matchupContentHidden').value,
+                content: document.getElementById('matchupContent').value, 
                 regionGroup: regionGroup,
                 regionSubgroup: regionSubgroup,
                 regionDetail: document.getElementById('detailAddress').value,

--- a/src/main/webapp/resources/js/matchup/updateMatchup.js
+++ b/src/main/webapp/resources/js/matchup/updateMatchup.js
@@ -79,6 +79,15 @@ function updateDropdownUI(list, displayElement, value) {
 
 // 수정하기 버튼 클릭 시, 서버로 데이터를 전송하는 메인 함수
 async function handleUpdate() {
+
+	// SmartEditor2의 textarea 값 반영
+	if (window.oEditors && oEditors.getById && oEditors.getById["matchupContent"]) {
+	    oEditors.getById["matchupContent"].exec("UPDATE_CONTENTS_FIELD", []);
+	} else {
+	    alert("에디터가 아직 준비되지 않았습니다. 잠시 후 다시 시도해주세요.");
+	    return;
+	}
+	
     const data = collectFormData();
     if (!data.title || !data.content) {
         alert('매치업명과 소개글은 필수 항목입니다.');
@@ -127,7 +136,7 @@ function collectFormData() {
     const matchupData = {
         matchupId: document.getElementById('matchupId').value,
         title: document.getElementById('matchupTitle').innerText,
-        content: document.getElementById('matchupContent').innerText,
+        content: document.getElementById('matchupContent').value,
         languageId: document.querySelector('input[name="languageId"]').value,
         categoryId: document.querySelector('input[name="categoryId"]').value,
         startDay: document.querySelector('input[name="startDay"]').value,


### PR DESCRIPTION
## ✅ 요약 (Summary)
 매치업 수정 페이지에서 SmartEditor2 에디터 값이 정상적으로 반영되지 않던 문제 해결


## 🔑 변경 사항 (Key Changes)
updateMatchup.js 내 handleUpdate() 함수에 SmartEditor2의 명령 추가

collectFormData()에서 matchupContent 값을 .innerText → .value로 수정

SmartEditor2가 정상 동작하도록 에디터 초기화 스크립트 적용 여부 확인

## 📝 리뷰 요구사항 (To Reviewers)
 SmartEditor2 적용 방식 및 수정폼 입력값 수집 방식에 문제 없는지 확인 부탁드립니다

## 🔍 확인 방법 (How to Test)
로그인 후 방장인 matchup 접근 후 소개글을 SmartEditor2로 작성하고 ‘개설하기’ 클릭

상세 페이지에서 수정된 소개글이 정상 반영되는지 확인