### PR TITLE
feat: 멘토 상세보기(진행한 멘토스내역)

### DIFF
--- a/src/main/java/com/shinhan/memento/apicontroller/MentoDetailApiController.java
+++ b/src/main/java/com/shinhan/memento/apicontroller/MentoDetailApiController.java
@@ -1,0 +1,54 @@
+package com.shinhan.memento.apicontroller;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.shinhan.memento.common.exception.MemberException;
+import com.shinhan.memento.common.response.BaseResponse;
+import com.shinhan.memento.common.response.status.BaseExceptionResponseStatus;
+import com.shinhan.memento.dto.mentoDetail.MentoDetailClassDTO;
+import com.shinhan.memento.model.Member;
+import com.shinhan.memento.model.UserType;
+import com.shinhan.memento.service.MemberService;
+import com.shinhan.memento.service.MentosService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/mentodetail")
+public class MentoDetailApiController {
+	@Autowired
+	MemberService memberService;
+	
+	@Autowired
+	MentosService mentosService;
+
+	/**
+	 * 멘토 상세조회(진행한 멘토스내역 보기)
+	 */
+	@GetMapping("/classlist")
+	public BaseResponse<List<MentoDetailClassDTO>> showMentoDetailClassList(@RequestParam("mentoId") int mentoId,
+			@DateTimeFormat(pattern = "yyyy-MM-dd") Date lastCreatedAt) {
+		log.info("[MentoDetailApiController.showMentoDetailClassList]");
+		// mentoId 로 들어온 값이 유효한지 확인
+		Map<String, Object> memberParams = new HashMap<>();
+		memberParams.put("memberId", mentoId);
+		memberParams.put("userType", UserType.MENTO);
+		Member member = memberService.findMemberByIdAndUserType(memberParams);
+		if (member == null) {
+			throw new MemberException(BaseExceptionResponseStatus.CANNOT_FOUND_MENTO);
+		}
+		
+		return new BaseResponse<>(mentosService.showMentoDetailClassList(mentoId, lastCreatedAt));
+	}
+}

--- a/src/main/java/com/shinhan/memento/dto/mentoDetail/MentoDetailClassDTO.java
+++ b/src/main/java/com/shinhan/memento/dto/mentoDetail/MentoDetailClassDTO.java
@@ -19,4 +19,5 @@ public class MentoDetailClassDTO {
 	private String selectedDays;
 	private String region; // regionGroup + regionSubgroup
 	private int price;
+	private String createdAt;
 }

--- a/src/main/java/com/shinhan/memento/dto/mentoDetail/MentoDetailClassDTO.java
+++ b/src/main/java/com/shinhan/memento/dto/mentoDetail/MentoDetailClassDTO.java
@@ -1,0 +1,22 @@
+package com.shinhan.memento.dto.mentoDetail;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MentoDetailClassDTO {
+	private String mentosImg;
+	private String title;
+	private String mentoName;
+	private String userType;
+	private String startDay;
+	private String endDay;
+	private String startTime;
+	private String endTime;
+	private String selectedDays;
+	private String region; // regionGroup + regionSubgroup
+	private int price;
+}

--- a/src/main/java/com/shinhan/memento/mapper/MentosMapper.java
+++ b/src/main/java/com/shinhan/memento/mapper/MentosMapper.java
@@ -1,6 +1,7 @@
 package com.shinhan.memento.mapper;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -29,4 +30,6 @@ public interface MentosMapper {
 			@Param("offset") int offset);
 	
 	int countNowMember(int mentosId);
+
+	List<Mentos> showMentosListByMentoId(Map<String, Object> mentosParams);
 }

--- a/src/main/java/com/shinhan/memento/service/MentosService.java
+++ b/src/main/java/com/shinhan/memento/service/MentosService.java
@@ -268,7 +268,8 @@ public class MentosService {
 					.endTime(mentos.getEndTime().toString().substring(11))
 					.selectedDays(mentos.getSelectedDays())
 					.region(mentos.getRegionGroup()+" "+mentos.getRegionSubgroup())
-					.price(mentos.getPrice()).build();
+					.price(mentos.getPrice())
+					.createdAt(mentos.getCreatedAt().toString()).build();
 			
 			result.add(dto);
 		}

--- a/src/main/resources/Mybatis/mappers/MentosMapper.xml
+++ b/src/main/resources/Mybatis/mappers/MentosMapper.xml
@@ -98,7 +98,8 @@
 		SELECT inner_query.*, ROWNUM AS rnum
 		FROM (
 		SELECT *
-		FROM mentos
+		FROM
+		mentos
 		WHERE 1=1
 		<if test="regionGroup != null and regionGroup != ''">
 			AND region_group = #{regionGroup}
@@ -106,7 +107,8 @@
 		<if test="matchTypeId != null">
 			AND (
 			match_type_first = #{matchTypeId}
-			OR match_type_second = #{matchTypeId}
+			OR match_type_second
+			= #{matchTypeId}
 			OR match_type_third = #{matchTypeId}
 			)
 		</if>
@@ -119,7 +121,8 @@
 		AND status = 'ACTIVE'
 		ORDER BY created_at DESC
 		) inner_query
-		WHERE ROWNUM &lt;= #{offset} +15
+		WHERE ROWNUM
+		&lt;= #{offset} +15
 		)
 		WHERE rnum &gt; #{offset}
 	</select>
@@ -132,16 +135,21 @@
 		and
 		status='ACTIVE'
 	</select>
-	
-	<select id="showMentosListByMentoId" parameterType="map" resultMap="mentosResultMap">
-		select *
-		from mentos
-		where mento_id=#{mentoId}
+
+	<select id="showMentosListByMentoId" parameterType="map"
+		resultMap="mentosResultMap">
+		SELECT *
+		FROM (
+		SELECT *
+		FROM mentos
+		WHERE mento_id = #{mentoId}
 		<if test="createdAt != null">
-			and created_at &lt; #{createdAt}
+			AND created_at &lt; #{createdAt}
 		</if>
-		and status!='DELETE'
-		order by created_at desc
+		AND status != 'DELETE'
+		ORDER BY created_at DESC
+		)
+		WHERE ROWNUM &lt;= 12
 	</select>
 </mapper>
 

--- a/src/main/resources/Mybatis/mappers/MentosMapper.xml
+++ b/src/main/resources/Mybatis/mappers/MentosMapper.xml
@@ -30,9 +30,9 @@
 		<result property="createdAt" column="created_at" />
 		<result property="updatedAt" column="updated_at" />
 		<result property="status" column="status" />
-		<result property="matchTypeIdFirst" column="match_type_first" />
-		<result property="matchTypeIdSecond" column="match_type_second" />
-		<result property="matchTypeIdThird" column="match_type_third" />
+		<result property="matchTypeIdFirst" column="match_type_id_first" />
+		<result property="matchTypeIdSecond" column="match_type_id_second" />
+		<result property="matchTypeIdThird" column="match_type_id_third" />
 	</resultMap>
 
 

--- a/src/main/resources/Mybatis/mappers/MentosMapper.xml
+++ b/src/main/resources/Mybatis/mappers/MentosMapper.xml
@@ -132,5 +132,16 @@
 		and
 		status='ACTIVE'
 	</select>
+	
+	<select id="showMentosListByMentoId" parameterType="map" resultMap="mentosResultMap">
+		select *
+		from mentos
+		where mento_id=#{mentoId}
+		<if test="createdAt != null">
+			and created_at &lt; #{createdAt}
+		</if>
+		and status!='DELETE'
+		order by created_at desc
+	</select>
 </mapper>
 


### PR DESCRIPTION
## 요약 (Summary)
- [x] 멘토 상세보기 페이지에서 진행한 멘토스 내역 불러오는 백엔드 작업 완료했습니다.( 프론트는 나중에..)
- [x] DELETE 가 되는 애들은 최소인원을 충족하지 못해서 삭제된 애들이고 다른 상태들은 정상 진행중이거나 진행이 완료된 상태인데 이 친구들은 모두 출력되어야해서 쿼리문에서 DELETE 만 아닌 애들을 불러오도록 구현했습니다.
- [x] 리뷰보기와 마찬가지로 무한 스크롤로 구현을 하려고 했고, created_at 을 기준으로 내림차순 정렬하기 때문에 프론트에서 받은 마지막 데이터의 createdAt 을 기억해두었다가 그 다음 요청을 보낼 때에 사용해야 합니다!!

## 확인 방법 
```
select * from member;
```
를 데이터 베이스에서 실행시키고 유효한 멘토 멤버 id 를 가져와주세요.

```
select * from mentos;
```
도 실행해서 유효한 멘토스들의 데이터들이 잘들어있는지 확인해주세요.
그 다음 postman 으로 오셔서 아래의 uri 로 get 요청 보내주세요
```
http://localhost:9999/memento/mentodetail/classlist?mentoId=3&lastCreatedAt=2025-06-27
```

<img width="876" alt="스크린샷 2025-07-03 15 45 45" src="https://github.com/user-attachments/assets/c5946326-7b29-4036-9e46-def3ca0f352b" />

다음과 같이 데이터가 잘 오는 것을 확인할 수 있습니다