### PR TITLE
feat: 멘토 상세보기(홈)

### DIFF
--- a/src/main/java/com/shinhan/memento/apicontroller/MentoDetailApiController.java
+++ b/src/main/java/com/shinhan/memento/apicontroller/MentoDetailApiController.java
@@ -1,0 +1,48 @@
+package com.shinhan.memento.apicontroller;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.shinhan.memento.common.exception.MemberException;
+import com.shinhan.memento.common.response.BaseResponse;
+import com.shinhan.memento.common.response.status.BaseExceptionResponseStatus;
+import com.shinhan.memento.dto.mentoDetail.MentoDetailHomeDTO;
+import com.shinhan.memento.model.Member;
+import com.shinhan.memento.model.UserType;
+import com.shinhan.memento.service.MemberService;
+import com.shinhan.memento.service.MentosService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/mentodetail")
+public class MentoDetailApiController {
+	@Autowired
+	MemberService memberService;
+
+	@Autowired
+	MentosService mentosService;
+
+	@GetMapping("")
+	public BaseResponse<MentoDetailHomeDTO> showMentoDetailHome(@RequestParam int mentoId) {
+		log.info("[MentoDetailApiController.showmentoDetailHome]");
+
+		// mentoId 로 들어온 값이 유효한지 확인
+		Map<String, Object> memberParams = new HashMap<>();
+		memberParams.put("memberId", mentoId);
+		memberParams.put("userType", UserType.MENTO);
+		Member member = memberService.findMemberByIdAndUserType(memberParams);
+		if (member == null) {
+			throw new MemberException(BaseExceptionResponseStatus.CANNOT_FOUND_MENTO);
+		}
+		
+		return new BaseResponse<>(memberService.showMentoDetailHome(member));
+	}
+}

--- a/src/main/java/com/shinhan/memento/dto/mentoDetail/MentoDetailClassDTO.java
+++ b/src/main/java/com/shinhan/memento/dto/mentoDetail/MentoDetailClassDTO.java
@@ -1,0 +1,23 @@
+package com.shinhan.memento.dto.mentoDetail;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MentoDetailClassDTO {
+	private String mentosImg;
+	private String title;
+	private String mentoName;
+	private String userType;
+	private String startDay;
+	private String endDay;
+	private String startTime;
+	private String endTime;
+	private String selectedDays;
+	private String region; // regionGroup + regionSubgroup
+	private int price;
+	private String createdAt;
+}

--- a/src/main/java/com/shinhan/memento/dto/mentoDetail/MentoDetailClassDTO.java
+++ b/src/main/java/com/shinhan/memento/dto/mentoDetail/MentoDetailClassDTO.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class MentoDetailClassDTO {
+	private int mentosId; // 서버로 전송할 때 필요함
 	private String mentosImg;
 	private String title;
 	private String mentoName;

--- a/src/main/java/com/shinhan/memento/dto/mentoDetail/MentoDetailHomeDTO.java
+++ b/src/main/java/com/shinhan/memento/dto/mentoDetail/MentoDetailHomeDTO.java
@@ -1,0 +1,15 @@
+package com.shinhan.memento.dto.mentoDetail;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MentoDetailHomeDTO {
+	private String introduceComment;
+	private List<MentoDetailClassDTO> inProgressMentos; 
+}

--- a/src/main/java/com/shinhan/memento/mapper/MentosMapper.java
+++ b/src/main/java/com/shinhan/memento/mapper/MentosMapper.java
@@ -8,6 +8,7 @@ import org.apache.ibatis.annotations.Param;
 import com.shinhan.memento.dto.CategoryDTO;
 import com.shinhan.memento.dto.LanguageDTO;
 import com.shinhan.memento.dto.MatchTypeDTO;
+import com.shinhan.memento.dto.mentoDetail.MentoDetailClassDTO;
 import com.shinhan.memento.dto.mentos.CreateMentosDBDTO;
 import com.shinhan.memento.model.Mentos;
 
@@ -29,4 +30,6 @@ public interface MentosMapper {
 			@Param("offset") int offset);
 	
 	int countNowMember(int mentosId);
+	
+	List<Mentos> showInProgressMentosList(int mentoId);
 }

--- a/src/main/java/com/shinhan/memento/service/MemberService.java
+++ b/src/main/java/com/shinhan/memento/service/MemberService.java
@@ -1,28 +1,31 @@
 package com.shinhan.memento.service;
 
-import java.util.Map;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
-import com.shinhan.memento.mapper.MemberMapper;
-import com.shinhan.memento.model.Member;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shinhan.memento.dto.mentoDetail.MentoDetailClassDTO;
+import com.shinhan.memento.dto.mentoDetail.MentoDetailHomeDTO;
+import com.shinhan.memento.mapper.MemberMapper;
 import com.shinhan.memento.model.BaseStatus;
+import com.shinhan.memento.model.Member;
+import com.shinhan.memento.model.Mentos;
 import com.shinhan.memento.model.UserType;
 import com.shinhan.memento.util.DBUtil;
 
@@ -34,6 +37,9 @@ public class MemberService {
 	
 	@Autowired
 	MemberMapper memberMapper;
+	
+	@Autowired
+	MentosService mentosService;
 	
 	public Member findMemberById(int memberId) {
 		log.info("[MemberService.findMemberById]");
@@ -164,6 +170,43 @@ public class MemberService {
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+	}
+	
+	/**
+	 * 멘토 상세보기 페이지(홈화면)
+	 */
+	public MentoDetailHomeDTO showMentoDetailHome(Member member) {
+		log.info("[MemberService.showMentoDetailHome]");
+		String introduceComment = member.getIntroduceMento() == null ? "" : member.getIntroduceMento();
+		
+		// 그냥 진행 중인 최신 멘토스 딱 3개만 보여주기 
+		List<Mentos> mentosList = mentosService.showInProgressMentosList(member.getMemberId());
+		List<MentoDetailClassDTO> inProgressMentos = new ArrayList<>();
+		for(Mentos mentos : mentosList) {
+			MentoDetailClassDTO dto = MentoDetailClassDTO.builder()
+					.mentosId(mentos.getMentosId())
+					.mentosImg(mentos.getImage())
+					.title(mentos.getTitle())
+					.mentoName(member.getNickname())
+					.userType(member.getUserType().toString())
+					.startDay(mentos.getStartDay().toString())
+					.endDay(mentos.getEndDay().toString())
+					.startTime(mentos.getStartTime().toString().substring(11))
+					.endTime(mentos.getEndTime().toString().substring(11))
+					.selectedDays(mentos.getSelectedDays())
+					.region(mentos.getRegionGroup()+" "+mentos.getRegionSubgroup())
+					.price(mentos.getPrice())
+					.createdAt(mentos.getCreatedAt().toString()).build();
+			
+			inProgressMentos.add(dto);
+		}
+		
+		MentoDetailHomeDTO result = MentoDetailHomeDTO.builder()
+				.introduceComment(introduceComment)
+				.inProgressMentos(inProgressMentos)
+				.build();
+		
+		return result;
 	}
 
 }

--- a/src/main/java/com/shinhan/memento/service/MentosService.java
+++ b/src/main/java/com/shinhan/memento/service/MentosService.java
@@ -25,6 +25,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.shinhan.memento.dto.CategoryDTO;
 import com.shinhan.memento.dto.LanguageDTO;
 import com.shinhan.memento.dto.MatchTypeDTO;
+import com.shinhan.memento.dto.mentoDetail.MentoDetailClassDTO;
 import com.shinhan.memento.dto.mentos.CreateMentosDBDTO;
 import com.shinhan.memento.dto.mentos.CreateMentosDTO;
 import com.shinhan.memento.dto.mentos.GetMentosDTO;
@@ -246,5 +247,14 @@ public class MentosService {
 		}
 
 		return result;
+	}
+	
+	/**
+	 * 멘토 상세보기 페이지(홈화면)
+	 */
+	public List<Mentos> showInProgressMentosList(int memberId){
+		log.info("[MentoService.showInProgressMentosList]");
+		
+		return mentosMapper.showInProgressMentosList(memberId);
 	}
 }

--- a/src/main/resources/Mybatis/mappers/MentosMapper.xml
+++ b/src/main/resources/Mybatis/mappers/MentosMapper.xml
@@ -132,5 +132,19 @@
 		and
 		status='ACTIVE'
 	</select>
+	
+	<select id="showInProgressMentosList" parameterType="int" resultMap="mentosResultMap">
+		select *
+		from (select * from mentos
+			where mento_id=#{mentoId}
+			and start_day &lt; = sysdate
+			and end_day &gt; = sysdate
+			and status='ACTIVE'
+			order by start_day desc
+		)
+		where rownum &lt; = 3
+	</select>
+	
+	
 </mapper>
 

--- a/src/main/resources/Mybatis/mappers/MentosMapper.xml
+++ b/src/main/resources/Mybatis/mappers/MentosMapper.xml
@@ -48,8 +48,8 @@
 		region_detail,
 		content, price, times, created_at,
 		updated_at, status,
-		match_type_first, match_type_second,
-		match_type_third
+		match_type_id_first, match_type_id_second,
+		match_type_id_third
 		) VALUES (
 		seq_mentos_id.nextval, #{categoryId},
 		#{languageId}, #{mentoId}, #{title}, #{simpleContent},
@@ -106,10 +106,9 @@
 		</if>
 		<if test="matchTypeId != null">
 			AND (
-			match_type_first = #{matchTypeId}
-			OR match_type_second
-			= #{matchTypeId}
-			OR match_type_third = #{matchTypeId}
+			match_type_id_first = #{matchTypeId}
+			OR match_type_id_second = #{matchTypeId}
+			OR match_type_id_third = #{matchTypeId}
 			)
 		</if>
 		<if test="categoryId != null">


### PR DESCRIPTION
## 요약 (Summary)
- [x] 멘토 상세보기 에서 홈화면 보기 백엔드 구현했습니다!(프론트는 아직) 구현하다보니 dto 에 id 를 하나 추가해서 보내게되었는데 이 dto 가 다른 멘토 상세보기에서도 사용하고 있는 dto 라 이게 머지되고나면 분명 오류가 날거라서 수정이 필요할 것 같습니다!

## 확인 방법 
member 테이블에 introduce_mento 가 아마 null 일거라서 아래의 쿼리문을 활용해서 update 해주세요.
```
update member
set introduce_mento = '멘토 소개를 이렇게 이렇게 추가해볼게요.멘토 소개를 이렇게 이렇게 추가해볼게요.멘토 소개를 이렇게 이렇게 추가해볼게요.멘토 소개를 이렇게 이렇게 추가해볼게요.멘토 소개를 이렇게 이렇게 추가해볼게요.멘토 소개를 이렇게 이렇게 추가해볼게요.멘토 소개를 이렇게 이렇게 추가해볼게요.멘토 소개를 이렇게 이렇게 추가해볼게요.멘토 소개를 이렇게 이렇게 추가해볼게요.'
where member_id=3;
```

그리고 나서 Postman 으로 아래의 주소로 get 요청 보내주시면 
```
http://localhost:9999/memento/mentodetail?mentoId=3
```
<img width="1019" alt="스크린샷 2025-07-03 17 33 23" src="https://github.com/user-attachments/assets/de6eaaa2-29f7-43a9-bcdc-5eacdd30b21b" />

이렇게 잘 오는 것을 확인할 수 있습니다