### PR TITLE
feat: 메인페이지 랭킹기능 구현 완료

### DIFF
--- a/src/main/java/com/shinhan/memento/dto/PopularLanguageDTO.java
+++ b/src/main/java/com/shinhan/memento/dto/PopularLanguageDTO.java
@@ -11,8 +11,9 @@ import lombok.NoArgsConstructor;
 @Data
 @Builder
 public class PopularLanguageDTO {
-	// id 값 수정 완료
+	private int languageId;
     private String languageName;
+    private String languageImage;
     private int totalCount;
     
 }

--- a/src/main/java/com/shinhan/memento/service/MainPageService.java
+++ b/src/main/java/com/shinhan/memento/service/MainPageService.java
@@ -23,8 +23,8 @@ public class MainPageService {
         counts.put("totalActiveCount", mainPageMapper.selectTotalActiveCount());
         counts.put("totalMatchupCount", mainPageMapper.selectTotalMatchupCount());
         
-        counts.put("partnerCount", 100); // 예시 고정값
-        counts.put("visitorCount", 2500); // 예시 고정값
+        counts.put("partnerCount", 133); // 예시 고정값
+        counts.put("visitorCount", 2512); // 예시 고정값
         
         return counts;
     }

--- a/src/main/resources/Mybatis/mappers/PopularLanguageMapper.xml
+++ b/src/main/resources/Mybatis/mappers/PopularLanguageMapper.xml
@@ -5,37 +5,45 @@
 
 <mapper namespace="com.shinhan.memento.mapper.PopularLanguageMapper">
 
-  <select id="findPopularLanguages" resultType="com.shinhan.memento.dto.PopularLanguageDTO">
+  <resultMap id="popularLanguageMap" type="com.shinhan.memento.dto.PopularLanguageDTO">
+    <result property="languageId" column="languageId"/>
+    <result property="languageName" column="languageName"/>
+    <result property="languageImage" column="languageImage"/>
+    <result property="totalCount" column="totalCount"/>
+  </resultMap>
+
+  <select id="findPopularLanguages" resultMap="popularLanguageMap">
     <![CDATA[
-SELECT *
-FROM (
-    SELECT
-        l.language_id AS languageId,
-        l.language_name AS languageName,
-        COALESCE(k.keepgoing_count, 0) + COALESCE(mmu.matchup_count, 0) + COALESCE(mt.mentos_count, 0) AS totalCount
-    FROM language l
-    LEFT JOIN (
-        SELECT language_id, COUNT(*) AS keepgoing_count
-        FROM keepgoing
-        WHERE status = 'ACTIVE'
-        GROUP BY language_id
-    ) k ON l.language_id = k.language_id
-    LEFT JOIN (
-        SELECT language_id, COUNT(*) AS matchup_count
-        FROM matchup
-        WHERE status = 'ACTIVE'
-        GROUP BY language_id
-    ) mmu ON l.language_id = mmu.language_id
-    LEFT JOIN (
-        SELECT language_id, COUNT(*) AS mentos_count
-        FROM mentos
-        WHERE status = 'ACTIVE'
-        GROUP BY language_id
-    ) mt ON l.language_id = mt.language_id
-    WHERE l.status = 'ACTIVE'
-    ORDER BY COALESCE(k.keepgoing_count, 0) + COALESCE(mmu.matchup_count, 0) + COALESCE(mt.mentos_count, 0) DESC
-)
-WHERE ROWNUM <= 7
+	SELECT *
+	FROM (
+	    SELECT
+	        l.language_id AS languageId,
+	        l.language_name AS languageName,
+	        l.language_image AS languageImage,
+	        COALESCE(k.keepgoing_count, 0) + COALESCE(mmu.matchup_count, 0) + COALESCE(mt.mentos_count, 0) AS totalCount
+	    FROM language l
+	    LEFT JOIN (
+	        SELECT language_id, COUNT(*) AS keepgoing_count
+	        FROM keepgoing
+	        WHERE status = 'ACTIVE'
+	        GROUP BY language_id
+	    ) k ON l.language_id = k.language_id
+	    LEFT JOIN (
+	        SELECT language_id, COUNT(*) AS matchup_count
+	        FROM matchup
+	        WHERE status = 'ACTIVE'
+	        GROUP BY language_id
+	    ) mmu ON l.language_id = mmu.language_id
+	    LEFT JOIN (
+	        SELECT language_id, COUNT(*) AS mentos_count
+	        FROM mentos
+	        WHERE status = 'ACTIVE'
+	        GROUP BY language_id
+	    ) mt ON l.language_id = mt.language_id
+	    WHERE l.status = 'ACTIVE'
+	    ORDER BY COALESCE(k.keepgoing_count, 0) + COALESCE(mmu.matchup_count, 0) + COALESCE(mt.mentos_count, 0) DESC
+	)
+	WHERE ROWNUM <= 7
     ]]>
   </select>
 

--- a/src/main/webapp/resources/js/mainpage.js
+++ b/src/main/webapp/resources/js/mainpage.js
@@ -1,10 +1,5 @@
-// 1. cpath 오류 수정: JSP에서 선언한 전역 변수 CPATH를 사용
-// 2. 예외 처리 추가: 데이터가 부족해도 오류가 나지 않도록 방어 코드 추가
-// 3. 리팩토링: 멘토/멘티 렌더링 함수를 하나로 통합
-
 document.addEventListener('DOMContentLoaded', function() {
     
-    // JSP에서 선언해준 전역 변수 CPATH를 사용합니다.
     const apiBaseUrl = `${CPATH}/api`;
 
     Promise.all([
@@ -23,7 +18,6 @@ document.addEventListener('DOMContentLoaded', function() {
         const mentiList = mentiData.result || [];
         const languageList = languageData.result || [];
 
-        // 리팩토링된 함수를 호출합니다.
         renderUserRanking('mentor', '⭐', mentorList);
         renderUserRanking('menti', '🔥', mentiList);
         renderLanguageRanking(languageList);
@@ -55,10 +49,14 @@ function renderUserRanking(type, icon, data) {
         
         const imageUrl = user.profileImage && (user.profileImage.startsWith('http') || user.profileImage.startsWith('https'))
             ? user.profileImage
-            : `${CPATH}/resources/images/profile/${user.profileImage || 'default-profile.png'}`;
+            : `${CPATH}/resources/images/main1/${user.profileImage || 'logo.png'}`;
+        
+        const onclickAttr = type === 'mentor' 
+            ? `onclick="location.href='${CPATH}/member/detail/${user.memberId}'"` 
+            : '';
         
         return `
-            <div class="podium-place ${rankClass}" onclick="location.href='${CPATH}/member/detail/${user.memberId}'">
+            <div class="podium-place ${rankClass}" ${onclickAttr}>
                 <div class="winner-info">
                     <div class="winner-avatar">
                         <img src="${imageUrl}" alt="${user.nickname}">
@@ -80,10 +78,14 @@ function renderUserRanking(type, icon, data) {
         
         const imageUrl = user.profileImage && (user.profileImage.startsWith('http') || user.profileImage.startsWith('https'))
             ? user.profileImage
-            : `${CPATH}/resources/images/profile/${user.profileImage || 'default-profile.png'}`;
+            : `${CPATH}/resources/images/main1/${user.profileImage || 'logo.png'}`;
         
+        const onclickAttr = type === 'mentor' 
+            ? `onclick="location.href='${CPATH}/member/detail/${user.memberId}'"` 
+            : '';
+            
         return `
-            <div class="ranking-item" onclick="location.href='${CPATH}/member/detail/${user.memberId}'">
+            <div class="ranking-item" ${onclickAttr}>
                 <div class="rank-number">${index + 4}</div>
                 <div class="participant-info">
                     <div class="participant-avatar">
@@ -98,8 +100,6 @@ function renderUserRanking(type, icon, data) {
     tableBodyEl.innerHTML = tableHtml;
 }
 
-
-// 언어 랭킹을 그리는 함수 (클릭 이벤트 추가)
 function renderLanguageRanking(data) {
     const podiumEl = document.getElementById('languagePodium');
     const tableBodyEl = document.getElementById('languageTableBody');
@@ -113,20 +113,21 @@ function renderLanguageRanking(data) {
         const rank = index + 1;
         const rankClass = ['first', 'second', 'third'][rank - 1];
         const medal = ['🥇', '🥈', '🥉'][rank - 1];
+
+        const imageUrl = lang.languageImage && (lang.languageImage.startsWith('http') || lang.languageImage.startsWith('https'))
+            ? lang.languageImage
+            : `${CPATH}/resources/images/main1/${lang.languageImage || 'logo.png'}`;
         
         return `
-            <div class="podium-place ${rankClass}" onclick="location.href='${CPATH}/mentos/search?keyword=${lang.languageName}'">
+            <div class="podium-place ${rankClass}">
                 <div class="winner-info">
-                    <div class="winner-avatar">
-                        <img src="${CPATH}/resources/images/language/${lang.languageName.toLowerCase()}.png" alt="${lang.languageName}" class="language-icon">
-                    </div>
+                    <div class="winner-avatar"><img src="${imageUrl}" alt="${lang.languageName}" class="language-icon"></div>
                     <div class="winner-name">${lang.languageName}</div>
                     <div class="winner-rating">❤️ ${lang.totalCount}</div>
                 </div>
                 <div class="medal">${medal}</div>
                 <div class="podium-base ${rankClass}">${rank}</div>
-            </div>
-        `;
+            </div>`;
     }).join('');
     podiumEl.innerHTML = podiumHtml;
     
@@ -134,18 +135,19 @@ function renderLanguageRanking(data) {
     let tableHtml = tableData.map((lang, index) => {
         if (!lang) return '';
         
+        const imageUrl = lang.languageImage && (lang.languageImage.startsWith('http') || lang.languageImage.startsWith('https'))
+            ? lang.languageImage
+            : `${CPATH}/resources/images/main1/${lang.languageImage || 'logo.png'}`;
+
         return `
-            <div class="ranking-item" onclick="location.href='${CPATH}/mentos/search?keyword=${lang.languageName}'">
+            <div class="ranking-item">
                 <div class="rank-number">${index + 4}</div>
                 <div class="participant-info">
-                    <div class="participant-avatar">
-                        <img src="${CPATH}/resources/images/language/${lang.languageName.toLowerCase()}.png" alt="${lang.languageName}" class="language-icon">
-                    </div>
+                    <div class="participant-avatar"><img src="${imageUrl}" alt="${lang.languageName}" class="language-icon"></div>
                     <div class="participant-name">${lang.languageName}</div>
                 </div>
                 <div class="rating">❤️ ${lang.totalCount}</div>
-            </div>
-        `;
+            </div>`;
     }).join('');
     tableBodyEl.innerHTML = tableHtml;
 }

--- a/src/test/java/mapper/PopularMentiMapper.xml
+++ b/src/test/java/mapper/PopularMentiMapper.xml
@@ -4,20 +4,60 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.shinhan.memento.mapper.PopularMentiMapper">
-
-  <select id="findPopularMenti" resultType="com.shinhan.memento.dto.PopularMentiDTO">
-	  <![CDATA[
-	  SELECT * FROM (
-	    SELECT member_id AS memberId,
-	           nickname,
-	           profile_image_url AS profileImage,
-	           score
-	    FROM member
-	    WHERE user_type IN ('MENTI', 'AFFILIATES', 'PREMENTO')
-	    ORDER BY score DESC
-	  )
-	  WHERE ROWNUM <= 7
-	  ]]>
-  </select>
-
+    
+    <resultMap id="popularMentiMap" type="com.shinhan.memento.dto.PopularMentiDTO">
+        <result property="memberId" column="memberId"/>
+        <result property="nickname" column="nickname"/>
+        <result property="profileImage" column="profileImage"/>
+        <result property="score" column="score"/>
+    </resultMap>
+    
+    <select id="findPopularMenti" resultMap="popularMentiMap">
+    <![CDATA[
+		SELECT *
+		FROM (
+		    SELECT
+		        m.member_id AS memberId,
+		        m.nickname,
+		        m.profile_image_url AS profileImage,
+		        NVL(matchup_scores.score, 0) + NVL(mentos_scores.score, 0) + NVL(keepgoing_scores.score, 0) AS score
+		    FROM
+		        member m
+		    LEFT JOIN (
+		        SELECT
+		            member_id,
+		            SUM(CASE WHEN status = 'ACTIVE' THEN 1
+		                     WHEN status = 'INACTIVE' THEN 2
+		                     ELSE 0
+		                END) AS score
+		        FROM MEMBER_MATCHUP
+		        GROUP BY member_id
+		    ) matchup_scores ON m.member_id = matchup_scores.member_id
+		    LEFT JOIN (
+		        SELECT
+		            member_id,
+		            SUM(CASE WHEN status = 'ACTIVE' THEN 1
+		                     WHEN status = 'INACTIVE' THEN 2
+		                     ELSE 0
+		                END) AS score
+		        FROM MEMBER_MENTOS
+		        GROUP BY member_id
+		    ) mentos_scores ON m.member_id = mentos_scores.member_id
+		    LEFT JOIN (
+		        SELECT
+		            member_id,
+		            SUM(CASE WHEN status = 'ACTIVE' THEN 1
+		                     ELSE 0
+		                END) AS score
+		        FROM MEMBER_KEEPGOING
+		        GROUP BY member_id
+		    ) keepgoing_scores ON m.member_id = keepgoing_scores.member_id
+		    WHERE
+		        m.user_type IN ('MENTI', 'AFFILIATES', 'PREMENTO')
+		    ORDER BY
+		        score DESC, m.member_id ASC
+		)
+		WHERE ROWNUM <= 7
+    ]]>
+    </select>
 </mapper>


### PR DESCRIPTION
## 요약 (Summary)
- 메인페이지 멘토랭킹/ 멘티랭킹/ 언어 랭킹 구현 완료

## 🔑 변경 사항 (Key Changes)
<수정>
- mainpage.jsp
- mainpage.js
- MainPageService 

PopularLanguageDTO에 languageImage 추가 (DB에도 - language 테이블에 language_lmage 추가

## 📝 리뷰 요구사항 (To Reviewers)

- 알맞은 조건으로 랭킹이 구현되는가.

* 멘토 랭킹 : 멘토스에서 해당 멘토스_id에 관한 리뷰 점수 총합 (score)에 리뷰 수를 나눈 평균 값
* 멘티 랭킹 : 매치업, 멘토스의 경우 활동중 (ACTIVE) - 1점 / 수료(INACTIVE) - 2점 이고 / 킵고잉 경우 가입 후 활동 (ACTIVE) -1점, 탈퇴 시 - 0점 으로 환산해서 낸 해당 유저의 점수 총합으로 랭킹
* 언어 랭킹 : 매치업, 멘토스에 가장 많은 선택을 받은 언어 랭킹 

## 확인 방법 
