### PR TITLE
fix: 매치업 UI 통일 및 매치업 List 하단 바 고정

### DIFF
--- a/src/main/webapp/WEB-INF/views/matchup/matchupDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/matchup/matchupDetail.jsp
@@ -265,6 +265,8 @@
 			</div>
 		</div>
 	</div>
+	
+	
 	<script>
       const loggedInMemberId = "${sessionScope.loginUser.memberId}";
       const cpath = "${cpath}";

--- a/src/main/webapp/WEB-INF/views/matchup/matchupList.jsp
+++ b/src/main/webapp/WEB-INF/views/matchup/matchupList.jsp
@@ -1,8 +1,8 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
-   pageEncoding="UTF-8"%>
+	pageEncoding="UTF-8"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <%@ page
-   import="java.util.List, java.util.Map, java.util.ArrayList, java.util.HashMap"%>
+	import="java.util.List, java.util.Map, java.util.ArrayList, java.util.HashMap"%>
 
 <c:set var="cpath" value="${pageContext.servletContext.contextPath}" />
 <!DOCTYPE html>
@@ -13,153 +13,210 @@
 <link rel="stylesheet" href="${cpath}/resources/css/matchupList.css">
 <link rel="stylesheet"
 	href="${pageContext.request.contextPath}/resources/css/mainpage/notificationModal.css">
+	
+<link rel="stylesheet"
+	href="${pageContext.request.contextPath}/resources/css/mainpage/login.css">
+<link rel="stylesheet"
+	href="${pageContext.request.contextPath}/resources/css/mainpage/notificationModal.css">
 </head>
 <body>
 
 	<div class="header-fixed">
-	   <%@ include file="../common/logout_header.jsp"%>
+		<c:choose>
+			<c:when test="${not empty sessionScope.loginUser}">
+				<%@ include file="../common/logout_header.jsp"%>
+			</c:when>
+			<c:otherwise>
+				<%@ include file="../common/login_header.jsp"%>
+			</c:otherwise>
+		</c:choose>
+		<%@ include file="../mainpage/notificationModal.jsp"%>
+		<div id="modalBackdrop"
+			style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0, 0, 0, 0.5); z-index: 999;"
+			onclick="closeModal()"></div>
+
+		<div id="loginModal"
+			style="display: none; position: fixed; top: 20%; left: 39%; transform: translateX(-50%); z-index: 1000;">
+
+			<%@ include file="../mainpage/login.jsp"%>
+			<script
+				src="${pageContext.request.contextPath}/resources/js/notification.js"></script>
+
+		</div>
 	</div>
-	  <jsp:include page="../mainpage/notificationModal.jsp" />
-<div class="container">
- <div class="content-wrap">
-   <div class="div">
-      <div class="frame-3657">
-         <div class="frame-390">
-            <div class="keepgoing-filter-and-make">
-                 <div class="detail-select">
-                     <div class="detail-select-li">
-                         <select name="regionGroup" class="filter-select" onchange="applyFilters()">
-                             <option value="">   지역 (전체)   </option>
-                         <c:forEach var="region" items="${regionGroups}">
-                            <option value="${region}" ${param.regionGroup == region ? 'selected' : ''}>${region}</option>
-                         </c:forEach>
-                         </select>
-                     </div>
-                     <div class="detail-select-li2">
-                         <select name="categoryId" class="filter-select" onchange="applyFilters()">
-                             <option value="">   학습유형 (전체)   </option>
-                             <c:forEach var="cat" items="${categories}">
-                            <option value="${cat.categoryId}" ${param.categoryId == cat.categoryId ? 'selected' : ''}>${cat.categoryName}</option>
-                         </c:forEach>
-                         </select>
-                     </div>
-                     <div class="detail-select-li">
-                          <select name="selectedDays" class="filter-select" onchange="applyFilters()">
-                             <option value="">   요일 (전체)   </option>
-                             <option value="MON" ${param.selectedDays == 'MON' ? 'selected' : ''}>월요일</option>
-                             <option value="TUE" ${param.selectedDays == 'TUE' ? 'selected' : ''}>화요일</option>
-                             <option value="WED" ${param.selectedDays == 'WED' ? 'selected' : ''}>수요일</option>
-                             <option value="THU" ${param.selectedDays == 'THU' ? 'selected' : ''}>목요일</option>
-                             <option value="FRI" ${param.selectedDays == 'FRI' ? 'selected' : ''}>금요일</option>
-                             <option value="SAT" ${param.selectedDays == 'SAT' ? 'selected' : ''}>토요일</option>
-                             <option value="SUN" ${param.selectedDays == 'SUN' ? 'selected' : ''}>일요일</option>
-                         </select>
-                     </div>
-                     <div class="detail-select-li">
-                         <select name="languageId" class="filter-select" onchange="applyFilters()">
-                             <option value="">   언어 (전체)   </option>
-                             <c:forEach var="lang" items="${languages}">
-                            <option value="${lang.languageId}" ${param.languageId == lang.languageId ? 'selected' : ''}>${lang.languageName}</option>
-                         </c:forEach>
-                         </select>
-                     </div>
-                 </div>
-            </div>
-            <button class="group-389" type="button"
-               onclick="location.href='${pageContext.request.contextPath}/matchup/createMatchup'">
-               새로운 매치업 작성하기</button>
-         </div>
-         <div class="frame-3694">
-            <c:forEach var="matchup" items="${matchupList}">
-               <div class="matchup-cardview" onclick="location.href='${cpath}/matchup/matchupDetail?id=${matchup.matchupId}'">
-                  <div class="rectangle-48"></div>
-                  <div class="div3">${matchup.regionGroup}</div>
-                  <div class="icon-time-04">
-                     <img class="icon-time-clock-outlined"
-                        src="${cpath}/resources/images/icon_time.svg" />
-                  </div>
-                  <div class="_2025-06-13-2025-06-20">${matchup.formattedStartDate}-
-                     ${matchup.formattedEndDate}</div>
-                  <div class="_15-00-17-00">${matchup.formattedStartTime}-
-                     ${matchup.formattedEndTime}</div>
-                  <div class="icon-time-02">
-                     <img class="icon-time-calendar-01"
-                        src="${cpath}/resources/images/icon-calendar.svg" />
-                  </div>
-                  <div class="_03-05">${matchup.formattedMemberCount}</div>
-                  <div class="_70-000">₩${matchup.formattedPrice}</div>
-                  <div class="div4">모집인원</div>
-                  <div class="icon-user-05">
-                     <img class="user-users-group"
-                        src="${cpath}/resources/images/icon-user.svg" />
-                  </div>
-                  <div class="div5">${matchup.title}</div>
-                  <div class="icon-maps-04">
-                     <img class="icon-maps-map-pin"
-                        src="${cpath}/resources/images/icon-map-black.svg" />
-                  </div>
-                  <img class="_1" src="${cpath}/resources/images/profile.svg" />
-                  <div class="group-414">
-                     <div class="java-c">#${matchup.languageName} #${matchup.categoryName}</div>
-                  </div>
-                  <div class="badges-wrapper">
-                      <c:if test="${not empty matchup.recruit}">
-                          <c:choose>
-                              <c:when test="${matchup.recruit == '마감임박'}">
-                                  <div class="badge badge-urgent">${matchup.recruit}</div>
-                              </c:when>
-                              <c:when test="${matchup.recruit == '모집완료'}">
-                                  <div class="badge badge-completed">${matchup.recruit}</div>
-                              </c:when>
-                              <c:otherwise>
-                                  <div class="badge badge-recruiting">${matchup.recruit}</div>
-                              </c:otherwise>
-                          </c:choose>
-                      </c:if>
-                      <c:if test="${matchup.hasMento}">
-						<c:choose>
-						  <c:when test="${matchup.mentoId != null && matchup.mentoId > 0}">
-						      <div class="badge badge-mentor-completed">멘토 선정 완료</div>
-						  </c:when>
-						  <c:otherwise>
-						      <div class="badge badge-mentor">멘토 모집중</div>
-						  </c:otherwise>
-						</c:choose>
-                      </c:if>
-                  </div>
-               </div>
-            </c:forEach>
-         </div>
-         <div class="pagemove-list">
-		    <c:if test="${paginationResult.pagination.page > 1}">
-		        <div class="page-back-btn" onclick="applyFilters(${paginationResult.pagination.page - 1})">
-		            <img class="vuesax-linear-arrow-left" src="${cpath}/resources/images/arrow-left.svg" />
-		        </div>
-		    </c:if>
-		
-		    <c:forEach var="page" begin="${paginationResult.startPage}" end="${paginationResult.endPage}">
-		        <div class="${page == paginationResult.pagination.page ? 'page-li-btn-seleted-page' : 'page-li-btn'}" onclick="applyFilters(${page})">
-		            <div class="${page == paginationResult.pagination.page ? 'd-2-b-12-white' : 'd-2-r-12-black'}">${page}</div>
-		        </div>
-		    </c:forEach>
-		
-		    <c:if test="${paginationResult.pagination.page < paginationResult.totalPageCount}">
-		        <div class="page-after-btn" onclick="applyFilters(${paginationResult.pagination.page + 1})">
-		            <img class="vuesax-linear-arrow-right" src="${cpath}/resources/images/arrow-right.svg" />
-		        </div>
-		    </c:if>
-		 </div>
-      </div>
-   </div>
-   </div>
-</div>
-   
-<script>
+	<div class="container">
+		<div class="content-wrap">
+			<div class="div">
+				<div class="frame-3657">
+					<div class="frame-390">
+						<div class="keepgoing-filter-and-make">
+							<div class="detail-select">
+								<div class="detail-select-li">
+									<select name="regionGroup" class="filter-select"
+										onchange="applyFilters()">
+										<option value="">지역 (전체)</option>
+										<c:forEach var="region" items="${regionGroups}">
+											<option value="${region}"
+												${param.regionGroup == region ? 'selected' : ''}>${region}</option>
+										</c:forEach>
+									</select>
+								</div>
+								<div class="detail-select-li2">
+									<select name="categoryId" class="filter-select"
+										onchange="applyFilters()">
+										<option value="">학습유형 (전체)</option>
+										<c:forEach var="cat" items="${categories}">
+											<option value="${cat.categoryId}"
+												${param.categoryId == cat.categoryId ? 'selected' : ''}>${cat.categoryName}</option>
+										</c:forEach>
+									</select>
+								</div>
+								<div class="detail-select-li">
+									<select name="selectedDays" class="filter-select"
+										onchange="applyFilters()">
+										<option value="">요일 (전체)</option>
+										<option value="MON"
+											${param.selectedDays == 'MON' ? 'selected' : ''}>월요일</option>
+										<option value="TUE"
+											${param.selectedDays == 'TUE' ? 'selected' : ''}>화요일</option>
+										<option value="WED"
+											${param.selectedDays == 'WED' ? 'selected' : ''}>수요일</option>
+										<option value="THU"
+											${param.selectedDays == 'THU' ? 'selected' : ''}>목요일</option>
+										<option value="FRI"
+											${param.selectedDays == 'FRI' ? 'selected' : ''}>금요일</option>
+										<option value="SAT"
+											${param.selectedDays == 'SAT' ? 'selected' : ''}>토요일</option>
+										<option value="SUN"
+											${param.selectedDays == 'SUN' ? 'selected' : ''}>일요일</option>
+									</select>
+								</div>
+								<div class="detail-select-li">
+									<select name="languageId" class="filter-select"
+										onchange="applyFilters()">
+										<option value="">언어 (전체)</option>
+										<c:forEach var="lang" items="${languages}">
+											<option value="${lang.languageId}"
+												${param.languageId == lang.languageId ? 'selected' : ''}>${lang.languageName}</option>
+										</c:forEach>
+									</select>
+								</div>
+							</div>
+						</div>
+						<button class="group-389" type="button"
+							onclick="location.href='${pageContext.request.contextPath}/matchup/createMatchup'">
+							새로운 매치업 작성하기</button>
+					</div>
+					<div class="frame-3694">
+						<c:forEach var="matchup" items="${matchupList}">
+							<div class="matchup-cardview"
+								onclick="location.href='${cpath}/matchup/matchupDetail?id=${matchup.matchupId}'">
+								<div class="rectangle-48"></div>
+								<div class="div3">${matchup.regionGroup}</div>
+								<div class="icon-time-04">
+									<img class="icon-time-clock-outlined"
+										src="${cpath}/resources/images/icon_time.svg" />
+								</div>
+								<div class="_2025-06-13-2025-06-20">${matchup.formattedStartDate}-
+									${matchup.formattedEndDate}</div>
+								<div class="_15-00-17-00">${matchup.formattedStartTime}-
+									${matchup.formattedEndTime}</div>
+								<div class="icon-time-02">
+									<img class="icon-time-calendar-01"
+										src="${cpath}/resources/images/icon-calendar.svg" />
+								</div>
+								<div class="_03-05">${matchup.formattedMemberCount}</div>
+								<div class="_70-000">₩${matchup.formattedPrice}</div>
+								<div class="div4">모집인원</div>
+								<div class="icon-user-05">
+									<img class="user-users-group"
+										src="${cpath}/resources/images/icon-user.svg" />
+								</div>
+								<div class="div5">${matchup.title}</div>
+								<div class="icon-maps-04">
+									<img class="icon-maps-map-pin"
+										src="${cpath}/resources/images/icon-map-black.svg" />
+								</div>
+								<img class="_1" src="${cpath}/resources/images/profile.svg" />
+								<div class="group-414">
+									<div class="java-c">#${matchup.languageName}
+										#${matchup.categoryName}</div>
+								</div>
+								<div class="badges-wrapper">
+									<c:if test="${not empty matchup.recruit}">
+										<c:choose>
+											<c:when test="${matchup.recruit == '마감임박'}">
+												<div class="badge badge-urgent">${matchup.recruit}</div>
+											</c:when>
+											<c:when test="${matchup.recruit == '모집완료'}">
+												<div class="badge badge-completed">${matchup.recruit}</div>
+											</c:when>
+											<c:otherwise>
+												<div class="badge badge-recruiting">${matchup.recruit}</div>
+											</c:otherwise>
+										</c:choose>
+									</c:if>
+									<c:if test="${matchup.hasMento}">
+										<c:choose>
+											<c:when
+												test="${matchup.mentoId != null && matchup.mentoId > 0}">
+												<div class="badge badge-mentor-completed">멘토 선정 완료</div>
+											</c:when>
+											<c:otherwise>
+												<div class="badge badge-mentor">멘토 모집중</div>
+											</c:otherwise>
+										</c:choose>
+									</c:if>
+								</div>
+							</div>
+						</c:forEach>
+					</div>
+					<div class="pagemove-list">
+						<c:if test="${paginationResult.pagination.page > 1}">
+							<div class="page-back-btn"
+								onclick="applyFilters(${paginationResult.pagination.page - 1})">
+								<img class="vuesax-linear-arrow-left"
+									src="${cpath}/resources/images/arrow-left.svg" />
+							</div>
+						</c:if>
+
+						<c:forEach var="page" begin="${paginationResult.startPage}"
+							end="${paginationResult.endPage}">
+							<div
+								class="${page == paginationResult.pagination.page ? 'page-li-btn-seleted-page' : 'page-li-btn'}"
+								onclick="applyFilters(${page})">
+								<div
+									class="${page == paginationResult.pagination.page ? 'd-2-b-12-white' : 'd-2-r-12-black'}">${page}</div>
+							</div>
+						</c:forEach>
+
+						<c:if
+							test="${paginationResult.pagination.page < paginationResult.totalPageCount}">
+							<div class="page-after-btn"
+								onclick="applyFilters(${paginationResult.pagination.page + 1})">
+								<img class="vuesax-linear-arrow-right"
+									src="${cpath}/resources/images/arrow-right.svg" />
+							</div>
+						</c:if>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<script src="${pageContext.request.contextPath}/resources/js/header.js"></script>
+	<script>
+	    const CPATH = "${cpath}";
+	</script>
+	<script src="${pageContext.request.contextPath}/resources/js/mainpage.js"></script>
+</body>
+
+	<script>
    const cpath = '${cpath}';
 </script>
 
-<script src="${cpath}/resources/js/matchup/matchupList.js"></script>
-<script src="${pageContext.request.contextPath}/resources/js/header.js"></script>
-<script src="${pageContext.request.contextPath}/js/notification.js"></script>
+	<script src="${cpath}/resources/js/matchup/matchupList.js"></script>
+	<script src="${pageContext.request.contextPath}/resources/js/header.js"></script>
+	<script src="${pageContext.request.contextPath}/js/notification.js"></script>
 </body>
 </html>

--- a/src/main/webapp/resources/css/mainpage/main.css
+++ b/src/main/webapp/resources/css/mainpage/main.css
@@ -20,7 +20,6 @@ body {
 	background: #fff;
 	box-sizing: border-box;
 	width: 100vw;
-	overflow-x: hidden;
 }
 
 /* 슬라이더 스타일 */
@@ -352,48 +351,7 @@ rotate(
 	color: #00b39e;
 }
 
-/* 푸터 */
-footer {
-	background-color: #FAFDFF;
-	color: #555;
-	padding: 40px 20px 20px;
-	font-size: 14px;
-	line-height: 1.6;
-}
 
-footer a {
-	color: #1a73e8;
-	text-decoration: none;
-	margin-right: 15px;
-	transition: color 0.3s ease;
-}
-
-footer a:hover {
-	color: #0c47b7;
-	text-decoration: underline;
-}
-
-.footer-links {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 10px;
-	margin-top: 10px;
-}
-
-.footer-info strong {
-	font-weight: 700;
-	font-size: 16px;
-	color: #222;
-}
-
-.footer-bottom {
-	margin-top: 30px;
-	font-size: 13px;
-	color: #777;
-	border-top: 1px solid #ccc;
-	padding-top: 15px;
-	text-align: center;
-}
 
 /* 반응형 */
 @media ( max-width : 768px) {
@@ -512,7 +470,6 @@ footer a:hover {
     position: relative;
 }
 
-/* 배경 장식 요소 */
 .home-page-3::before {
     content: '';
     position: absolute;
@@ -782,7 +739,6 @@ body {
 	background: #fff;
 	box-sizing: border-box;
 	width: 100vw;
-	overflow-x: hidden;
 	z-index: 999;
 }
 
@@ -920,6 +876,7 @@ body {
 	text-align: center;
 	margin-top: 0px;
 	margin-bottom: 40px;
+	white-space: nowrap;
 }
 
 .medal {
@@ -1055,65 +1012,50 @@ body {
 	/* ========================================
    4. FOOTER SECTION
    ======================================== */
-	footer {
-		background-color: #FAFDFF;
-		color: #555;
-		padding: 40px 20px 20px;
-		font-family: 'D2Coding', monospace;
-		font-size: 14px;
-		line-height: 1.6;
-		width: 100vw;
-	}
-	footer a {
-		color: #1a73e8;
-		text-decoration: none;
-		margin-right: 15px;
-		transition: color 0.3s ease;
-	}
-	footer a:hover {
-		color: #0c47b7;
-		text-decoration: underline;
-	}
-	.footer-links {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 10px;
-		margin-top: 10px;
-	}
-	.footer-link {
-		color: #1a73e8;
-		text-decoration: none;
-		transition: color 0.3s ease;
-	}
-	.footer-info strong {
-		font-weight: 700;
-		font-size: 16px;
-		color: #222;
-	}
-	.footer-info .business-link {
-		font-size: 13px;
-		color: #3b82f6;
-	}
-	.footer-contact {
-		font-size: 14px;
-		color: #444;
-	}
-	.footer-bottom {
-		margin-top: 30px;
-		font-size: 13px;
-		color: #777;
-		border-top: 1px solid #ccc;
-		padding-top: 15px;
-	}
 
-	/* 하단 Footer */
-	footer { width:100vw;
-		margin-left: calc(-1 * ( 100vw - 100%)/2);
-		padding: 40px 20px;
-		box-sizing: border-box;
-	}
-	footer a {
-		margin-right: 10px;
-		font-size: 13px;
-	}
+footer {
+    background-color: #FAFDFF;
+    color: #555;
+    font-family: 'D2Coding', monospace;
+    font-size: 14px;
+    line-height: 1.6;
+    box-sizing: border-box;
+    padding: 40px 20px 20px;
+
+    width: 100vw;
+    margin-left: calc(-50vw + 50%);
+}
+
+footer a {
+    color: #1a73e8;
+    text-decoration: none;
+    margin-right: 15px;
+    transition: color 0.3s ease;
+}
+
+footer a:hover {
+    color: #0c47b7;
+    text-decoration: underline;
+}
+
+.footer-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.footer-info strong {
+    font-weight: 700;
+    font-size: 16px;
+    color: #222;
+}
+
+.footer-bottom {
+    margin-top: 30px;
+    font-size: 13px;
+    color: #777;
+    border-top: 1px solid #ccc;
+    padding-top: 15px;
+    text-align: center;
 }

--- a/src/main/webapp/resources/css/matchupDetail.css
+++ b/src/main/webapp/resources/css/matchupDetail.css
@@ -4,9 +4,11 @@
     padding: 0;
 }
 body {
-    font-family: "Inter", "D2Coding", sans-serif;
-    background-color: #f5f6f8;
-    padding-top: 80px;
+	font-family: "Inter", "D2Coding", sans-serif;
+	background-color: #f5f6f8;
+	padding-top: 120px;
+	width: 100%;
+	overflow-x: hidden;
 }
 a {
     text-decoration: none;
@@ -24,15 +26,17 @@ a {
 /* --- 페이지 전체 레이아웃 --- */
 .container {
     width: 100%;
+    padding: 0 60px;
+    max-width: 1400px;
+    margin: 0 auto;
 }
 .main-content, .main-content-wrapper {
     width: 100%;
-    max-width: 1100px;
+    max-width: 1000px;
     margin: 0 auto;
-    padding: 40px 20px;
     display: flex;
     flex-direction: column;
-    gap: 30px;
+    gap: 40px;
 }
 
 /* --- 상단 정보 영역 --- */
@@ -66,10 +70,13 @@ a {
 }
 .info-tag.mento.completed {
     background: #868e96;
+    color : rgb(62 64 68);
+    font-family: "D2Coding-Bold", sans-serif;
 }
 .info-tag.category {
     background: #e9ecef;
     color: #757575;
+    font-family: "D2Coding-Bold", sans-serif;
 }
 .matchup-title {
     font-size: 32px;
@@ -121,7 +128,7 @@ a {
   align-items: center;
   flex-wrap: nowrap;
   gap: 20px;
-  border-top: 1px solid #f1f3f5;
+  border-top: 1px solid #e2e2e2;
   padding-top: 20px;
   width : 100%;
   
@@ -176,21 +183,21 @@ a {
     align-items: stretch;
 }
 .middle-area-left {
-    width: 66.66%;
+   flex: 1; /* 너비를 flex: 1로 변경 */
     display: flex;
     flex-direction: column;
     gap: 30px;
 }
 
 .middle-area-right {
-    width: 33.33%;
+    width: 300px; /* 너비를 300px로 고정 */
     display: flex;
     flex-direction: column;
     gap: 30px;
 }
 
 .middle-area-left .section-box {
-  min-height: 1000px;
+   min-height: 100%;
 }
 .section-box {
     background: #ffffff;

--- a/src/main/webapp/resources/css/matchupDetailLeader.css
+++ b/src/main/webapp/resources/css/matchupDetailLeader.css
@@ -42,27 +42,21 @@ body {
 }
 
 .top-info-category, .top-info-mento {
-	border-radius: 50px;
-	padding: 8px 15px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	font-family: "Inter-SemiBold", sans-serif;
-	font-size: 15px;
-	line-height: 150%;
-	letter-spacing: -0.023em;
-	font-weight: 600;
-	white-space: nowrap;
+    border-radius: 50px;
+    padding: 8px 15px;
+    font-family: "D2Coding-Bold", sans-serif;
+    font-size: 13px;
+    font-weight: 600;
+    white-space: nowrap;
 }
-
 .top-info-category {
-	background-color: #c2dbe9;
+	background-color: #e9ecef;
 	color: #757575;
 }
 
 .top-info-mento {
-	background-color: #1fa3d8;
-	color: #ffffff;
+	background-color: #4A90E2;
+	color: rgb(62 64 68);
 }
 
 .top-info-mento.completed {
@@ -168,7 +162,7 @@ body {
 .top-info-line {
 	width: 100%;
 	height: 1px;
-	background-color: #a6abbd;
+	background-color: #e2e2e2;
 	margin: 10px 0;
 }
 
@@ -631,10 +625,10 @@ body {
 .java-c2 {
 	color: rgba(0, 0, 0, 0.51);
 	text-align: center;
-	font-family: "Inter-Medium", sans-serif;
+	font-family: "D2Coding-Bold", sans-serif;
 	font-size: 10px;
 	line-height: 150%;
-	letter-spacing: -0.023em;
+	letter-spacing: -0.02em;
 	font-weight: 500;
 	white-space: nowrap;
 }

--- a/src/main/webapp/resources/css/matchupList.css
+++ b/src/main/webapp/resources/css/matchupList.css
@@ -51,20 +51,21 @@ html, body, *, *::before, *::after {
   margin: 0 auto;
 
   /* 콘텐츠 크기 제한 */
-  padding-left: 50px;
-  padding-right: 50px;
+  padding-left: 100px;
+  padding-right: 100px;
   max-width: 1500px;
   min-width: 400px;
   width: 100%;
 }
 
 .frame-390 {
-    display: flex;
-    align-items: center;
-    justify-content: space-between; 
-    width: 100%;
-    margin-bottom: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 30px;
 }
+
 
 span {
 	align-items: center;
@@ -74,24 +75,26 @@ span {
   display: flex;
   gap: 15px;
 }
+
 .keepgoing-filter-and-make {
-	display: flex;
-	flex-direction: row;
-	gap: 15px;
-	align-items: center;
-	justify-content: flex-start;
-	flex-shrink: 0;
-	width: 481px;
-	position: relative;
-	z-index: 10;
+  display: flex;
+  flex-direction: row;
+  gap: 15px;
+  align-items: center;
+   justify-content: space-between;
+  flex-grow: 1;
+  position: relative;
+  z-index: 10;
+   width: 100%;
 }
 
 .detail-select {
   display: flex;
-  flex-wrap: wrap; /* ✅ 여러 줄로 감기도록 */
-  gap: 16px;        /* ✅ 간격 명확히 */
+  gap: 16px;
   align-items: center;
   flex-wrap: nowrap;
+  flex-shrink: 0;
+  margin-left: -28%;
 }
 
 .detail-select-li {
@@ -201,6 +204,7 @@ button.group-389 {
     cursor: pointer;
     flex-shrink: 0; 
     transition: background-color 0.2s ease;
+    margin-left: 20%;
 }
 
 /* 2. hover 상태 */
@@ -473,15 +477,20 @@ transition: transform 0.3s ease, box-shadow 0.3s ease;
 	display: flex;
 	flex-direction: row;
 	gap: 10px;
-	align-items: flex-end;
+	align-items: center;
 	justify-content: center;
-	align-self: stretch;
-	flex-shrink: 0;
-	position: relative;
-	margin-top: 70px;
+	position: fixed;
+	bottom: 40px;
+	left: 50%;
+	transform: translateX(-50%);
+	z-index: 50;
+	background: none;
+	padding: 0;
+	border-radius: 0;
+	box-shadow: none;
+
 	cursor: pointer;
 }
-
 .page-back-btn {
 	border-radius: 5px;
 	border-style: solid;
@@ -612,49 +621,48 @@ transition: transform 0.3s ease, box-shadow 0.3s ease;
 
 .badge-recruiting {
   background-color: #EF6968;
+  color: rgb(62 64 68);
 }
 
 .badge-urgent {
   background-color: #D9534F;
+  color:rgb(62 64 68);
 }
 
 .badge-completed {
   background-color: #888888;
+  color:rgb(62 64 68);
 }
 
 .badge-mentor {
   background-color: #4A90E2;
+  color:rgb(62 64 68);
 }
 
 .badge-mentor-completed {
   background-color: #9DADC1;
+  color: rgb(62 64 68);
 }
 
-/* 카테고리 필터 검색 관련 */
-/* 모든 필터 select 박스 공통 스타일 */
 .filter-select {
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
-
-  /* 크기 및 레이아웃 */
-  padding: 10px 16px;
+  padding: 10px 0px;
   font-size: 14px;
   font-family: 'Inter', sans-serif;
   color: #333;
   background-color: #fff;
   min-width: 160px;
-  text-align: center; 	
-  /* ✅ 진짜 테두리 한 줄 */
+
+  text-align: center;
   border: 1px solid #ced4da;
   border-radius: 12px;
 
-  /* ✅ 이중 효과 제거 */
   box-shadow: none !important;
   outline: none !important;
   background-clip: padding-box;
 
-  /* ▼ 아이콘 */
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23666' viewBox='0 0 24 24'%3E%3Cpath d='M7 10l5 5 5-5'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 12px center;
@@ -663,8 +671,12 @@ transition: transform 0.3s ease, box-shadow 0.3s ease;
   cursor: pointer;
 }
 
+.filter-select option {
+  text-align: center;
+}
+
 .filter-select:last-child {
-  margin-right: 0; /* 마지막 select는 여백 제거 */
+  margin-right: 0;
 }
 
 .filter-select:hover {


### PR DESCRIPTION
## 📝 요약 (Summary)  
- 매치업 상세 및 목록 페이지 UI 요소 전반 정리  
- 매치업 목록 하단 고정 바(UI 컴포넌트) 위치 이슈 수정

## 🔑 변경 사항 (Key Changes)  
- 매치업 관련 JSP 및 CSS UI 통일 작업 진행  
- 목록 하단 고정 바가 화면에 항상 노출되도록 `position: fixed` 처리 및 여백 조정  
- 반응형 레이아웃에서 하단 바가 깨지던 문제 수정  
- 불필요한 CSS 속성 정리 및 공통화 적용

## 📌 리뷰 요구사항 (To Reviewers)  
- 목록 페이지 하단 고정 바가 모든 해상도에서 정상 노출되는지 확인 부탁드립니다.  
- 각종 브라우저(Chrome, Edge 등)에서 UI 깨짐 현상 여부 점검 부탁드립니다.  

## 🔍 확인 방법  
- `/matchup/matchupList` 접속 → 카테고리 변경 시 고정 바 유지되는지 확인  
- 상세 페이지(`/matchup/matchupDetail?id={}`) UI 정렬 및 여백 확인  